### PR TITLE
Allow earlier retirement ages

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -219,7 +219,7 @@ canvas {
         </div>
         <div class="form-group">
           <label for="retireAge">Desired retirement age</label>
-          <input type="number" id="retireAge" min="50" max="100" value="65" required />
+          <input type="number" id="retireAge" min="18" max="100" value="65" required />
         </div>
 
         <!-- ─── Replaced “Portfolio growth rate” radios with card-style inputs ─── -->


### PR DESCRIPTION
## Summary
- relax the retirement age limit so users can enter ages below 50

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff40f3860833385369d25fb89cf74