### PR TITLE
Fix mobile landing alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
     }
     html,
     body {
-      height: 100%;
+      min-height: 100vh;
+      overflow-x: hidden;
     }
     body {
       font-family: 'Inter', sans-serif;
@@ -27,10 +28,14 @@
       color: #fff;
       display: flex;
       flex-direction: column;
-      justify-content: center;
+      justify-content: flex-start;
       align-items: center;
       gap: 1.5rem;
       padding: calc(env(safe-area-inset-top,0)+2rem) 1rem 2rem;
+    }
+
+    @media (min-width: 700px) {
+      body { justify-content: center; }
     }
 
     /* 2. Make the container flex and allow wrapping */
@@ -124,7 +129,7 @@
 
     .info-box img {
       width: auto;
-      max-width: 100px;
+      max-width: 80px;
       height: auto;
       flex-shrink: 0;
       margin-right: 0.75rem;
@@ -140,11 +145,12 @@
         flex-direction: column;
         align-items: center;
         text-align: center;
+        gap: 1rem;
       }
       .info-box img {
         margin-right: 0;
         margin-bottom: 0.75rem;
-        max-width: 100px;
+        max-width: 60px;
       }
     }
 


### PR DESCRIPTION
## Summary
- use `min-height: 100vh` and remove vertical centering on small screens
- hide horizontal scrolling
- tweak info box image sizing and layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840044331488333ba9086ae3b818e07