### PR TITLE
Add imputed distribution warning

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -306,6 +306,14 @@ canvas {
   <div id="cashflow-caption"></div>
 </div>
 
+        <div class="warning-block">
+          ⚠️ Note: This calculator does not account for mandatory pension
+          withdrawals (imputed distributions from age 61). However, a prudent
+          investor would typically reinvest any excess amounts not needed for
+          spending. As a result, the long-term impact is broadly neutral, and
+          the projections remain a reasonable reflection of reality.
+        </div>
+
       <div id="console" class="error"></div>
 
       <!-- SFT warning modal -->


### PR DESCRIPTION
## Summary
- note that the FY Money calculator doesn't account for mandatory pension withdrawals

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_68409d0a81fc8333bb9f3b7e9dbfae04