### PR TITLE
Fix retirement age warning logic

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -480,12 +480,12 @@ canvas {
                   You’re a proprietary director who fully severs ties with the sponsoring company<br><br>
                   Please seek professional advice before relying on projections assuming early access.
                 </div>`;
-            } else if (retireAge < 75) {
+            } else if (retireAge >= 70 && retireAge < 75) {
               earlyWarning = `
                 <div class="warning-block">
                   ⚠️ Retirement Age Over 70 (Occupational Pensions &amp; PRBs)<br>
                   Most occupational pensions and Personal Retirement Bonds (PRBs) must be drawn down by age 70 under Irish Revenue rules.<br>
-                  If your selected retirement age is over 70, please be aware this may not be allowed for those pension types.<br><br>
+                  If your selected retirement age is between 70 and 74, please be aware this may not be allowed for those pension types.<br><br>
                   Note: The exception to this is PRSAs, which can remain unretired until age 75.<br><br>
                   Please seek professional advice to ensure your retirement plan complies with pension access rules.
                 </div>`;


### PR DESCRIPTION
## Summary
- ensure retirement age warning only triggers from 70 to 74
- clarify warning text for ages 70-74

## Testing
- `npx -y htmlhint fy-money-calculator.html`

------
https://chatgpt.com/codex/tasks/task_e_68409e818eac833385194ef78891ce0f