### PR TITLE
Update investment growth colour

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -467,7 +467,7 @@ function drawContribChart(showMax) {
         {
           label: 'Investment growth',
           data: dataG,
-          backgroundColor: '#6666ff',
+          backgroundColor: '#ff9933',
           stack: 'stack1'
         }
       ]


### PR DESCRIPTION
## Summary
- use `#ff9933` to color the Investment growth bars in the pension projection chart

## Testing
- `grep -n '#ff9933' -n pension-projection.html`

------
https://chatgpt.com/codex/tasks/task_e_6840c95febb88333a372cbb4c243cc14