### PR TITLE
Fix jspdf order in fy-money calculator

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -361,6 +361,7 @@ canvas {
 
       <!-- PASTE the JavaScript below this line -->
       <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/jspdf@^2"></script>
       <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@^3"></script>
       <script>
         const setHTML = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML = html; };
@@ -905,6 +906,5 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
 
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/jspdf@^2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure jspdf loads before autotable in fy-money-calculator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9fa14e48333a91d756c0a09721f