### PR TITLE
Fix jsPDF CDN links

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -361,12 +361,15 @@ canvas {
 
       <!-- PASTE the JavaScript below this line -->
       <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/jspdf@^2/dist/jspdf.umd.min.js"></script>
+      <!-- jsPDF core -->
+      <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+      <!-- expose constructor where our code expects it -->
       <script>
         window.jspdf = window.jspdf || {};
         window.jspdf.jsPDF = window.jspdf.jsPDF || window.jsPDF;
       </script>
-      <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@^3"></script>
+      <!-- AutoTable plugin -->
+      <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.0/dist/jspdf.plugin.autotable.min.js"></script>
       <script>
         const setHTML = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML = html; };
         const CPI = 0.023;


### PR DESCRIPTION
## Summary
- point jsPDF and AutoTable scripts at actual versioned files
- keep PDF library scripts above the main script

## Testing
- `grep -n jsPDF fy-money-calculator.html`

------
https://chatgpt.com/codex/tasks/task_e_6841dce2edb883338ed0a164bcc4ff5c