### PR TITLE
Fix chart export background

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -790,9 +790,20 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
   );
 
             latestRun = gatherData(reqCap, retirementYear);
+
+            function canvasToOpaquePng(canvas){
+              const ctx = canvas.getContext('2d');
+              ctx.save();
+              ctx.globalCompositeOperation = 'destination-over';
+              ctx.fillStyle = '#ffffff';
+              ctx.fillRect(0,0,canvas.width,canvas.height);
+              ctx.restore();
+              return canvas.toDataURL('image/png',1.0);
+            }
+
             latestRun.chartImgs = {
-              balance: balanceChart.toBase64Image(),
-              cashflow: cashflowChart.toBase64Image()
+              balance : canvasToOpaquePng(document.getElementById('balanceChart')),
+              cashflow: canvasToOpaquePng(document.getElementById('cashflowChart'))
             };
 
             document.getElementById('console').textContent = '';


### PR DESCRIPTION
## Summary
- embed opaque white background in exported charts so images don't have transparent backgrounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684200e96698833381ef638158c5f56d