### PR TITLE
Fix PDF callout sizing

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -942,32 +942,41 @@ function generatePDF() {
     alternateRowStyles: { fillColor: '#242424', textColor: '#fff' }
   });
 
-  /* prettier info-box ------------------------------------------------ */
-  const boxMargin = 30;                       // slimmer margins
+  /***** BEGIN: dynamic call-out height *****/
+  const boxMargin = 30;
   const boxX      = boxMargin;
   const boxW      = pageW - boxMargin * 2;
   const boxY      = doc.lastAutoTable.finalY + 35;
 
-  /* draw shell */
-  doc.setFillColor('#222222')                 // richer charcoal
-     .setDrawColor(ACCENT_CYAN)
-     .setLineWidth(2)
-     .roundedRect(boxX, boxY, boxW, 180, 14, 14, 'FD');
-
-  /* headline */
+  /* headline first (we need its height later) */
   doc.setFontSize(16).setFont(undefined,'bold').setTextColor(ACCENT_CYAN);
   const hdr = 'What does this calculator actually do?';
   doc.text(hdr, boxX + 24, boxY + 32);
 
-  /* body text */
+  /* body copy */
   const body =
     "•  It starts with the income you enjoy today and the share of that income you’d like to keep when you stop working.\n\n" +
     "•  It then works out how big your pension pot must be to fund that lifestyle all the way to age 100.\n\n" +
     "•  The maths reflects the investment growth rate you’re comfortable with and any other retirement income – such as State Pension, rental income or a defined-benefit plan.";
 
+  /* split + measure */
   doc.setFontSize(14).setFont(undefined,'normal').setTextColor('#ffffff');
-  const wrapped = doc.splitTextToSize(body, boxW - 48);   // 24 pt padding each side
-  doc.text(wrapped, boxX + 24, boxY + 60, { lineHeightFactor: 1.35 });
+  const wrapped      = doc.splitTextToSize(body, boxW - 48);
+  const lineHeight   = 18;                                // 14 pt font → ~18 pt leading
+  const bodyHeight   = wrapped.length * lineHeight;
+  const boxPaddingY  = 32 + 24;                           // 32 pt top space to headline +
+                                                          // 24 pt bottom padding
+  const boxH         = bodyHeight + boxPaddingY;
+
+  /* draw shell AFTER we know the height */
+  doc.setFillColor('#222222')
+     .setDrawColor(ACCENT_CYAN)
+     .setLineWidth(2)
+     .roundedRect(boxX, boxY, boxW, boxH, 14, 14, 'FD');
+
+  /* render body copy */
+  doc.text(wrapped, boxX + 24, boxY + 32 + 26, { lineHeightFactor: 1.3 });
+  /***** END: dynamic call-out height *****/
 
   addFooter(2);
   doc.addPage();


### PR DESCRIPTION
## Summary
- dynamically size the call-out box in the PDF rather than using a fixed height

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68431d1ba96883338e7365f6e5b6316a