### PR TITLE
Fix drop shadow state initialization

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -925,9 +925,8 @@ function generatePDF() {
   /* ───────────────── COVER ───────────────── */
   pageBG();
 
-  // One-time graphics state (18 % opacity drop-shadow)
-  // GState is a constructor, so instantiate it with `new`
-  const shadowGsObj = new doc.GState({ opacity: 0.18, blendMode: 'Multiply' });
+  // One-time graphics state (18 % opacity, Multiply blend mode)
+  const shadowGsObj = doc.GState({ opacity: 0.18, BM: 'Multiply' }); // no "new"; use BM not blendMode
   const shadowGsId  = doc.addGState(shadowGsObj);
   doc.setFontSize(48).setFont(undefined, 'bold').setTextColor(COVER_GOLD);
   doc.text("People's Planner", pageW / 2, 90, { align: 'center' });


### PR DESCRIPTION
## Summary
- correct GState usage to avoid crash in generatePDF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847224a368c83339580a8e658087318