### PR TITLE
Fix banner layout in fy-money-calculator

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -908,12 +908,18 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
           // warning  = {title, body, danger}
           // colours  = orange for normal, red for danger
           const accent  = warning.danger ? '#ff4b4b' : '#ffa500';
-          const gapTop  = 12;             // space above body text
-          const padX    = 12;             // inner left/right padding
+          const gapTop  = 12;        // space between title & body
+          const padX    = 12;        // left/right inner padding
           const bodyMax = w - padX * 2;
 
+          /*  Strip hard line-breaks and double-spaces that come from the
+              original HTML <br> tags.  Bullet (•) characters are kept.  */
+          const cleanBody = warning.body
+            .replace(/\s*\n+\s*/g, ' ')
+            .replace(/\s{2,}/g, ' ');
+
           // text lines
-          const bodyLines = doc.splitTextToSize(warning.body, bodyMax);
+          const bodyLines = doc.splitTextToSize(cleanBody, bodyMax);
           const bodyH     = bodyLines.length * 11;   // 11 pt line step
 
           // total height: title (10 pt) + gap + body + bottom padding
@@ -930,7 +936,10 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
 
           // body
           doc.setFontSize(8).setFont(undefined,'normal');
-          doc.text(bodyLines, x + padX, y + 14 + gapTop, { lineHeightFactor: 1.3 });
+          doc.text(bodyLines,
+                   x + padX,
+                   y + 14 + gapTop,
+                   { maxWidth: bodyMax, lineHeightFactor: 1.3, align: 'justify' });
 
           return h;        // caller moves cursor by h (+ desired gap)
         }


### PR DESCRIPTION
## Summary
- improve banner rendering logic in fy-money-calculator
- strip newline artifacts before text wrapping
- justify banner body text for nicer layout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847504a88008333a6b8f2542e28ce29