### PR TITLE
Remove text justification in banners

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -936,10 +936,12 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
 
           // body
           doc.setFontSize(8).setFont(undefined,'normal');
-          doc.text(bodyLines,
-                   x + padX,
-                   y + 14 + gapTop,
-                   { maxWidth: bodyMax, lineHeightFactor: 1.3, align: 'justify' });
+          doc.text(
+            bodyLines,
+            x + padX,
+            y + 14 + gapTop,
+            { maxWidth: bodyMax, lineHeightFactor: 1.32 }
+          );
 
           return h;        // caller moves cursor by h (+ desired gap)
         }


### PR DESCRIPTION
## Summary
- fix banner text spacing in the FY Money Calculator PDF export

## Testing
- `tidy -errors fy-money-calculator.html`

------
https://chatgpt.com/codex/tasks/task_e_684752b350a08333af3fc7a7cebd06f4