### PR TITLE
Update warning block HTML capture

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -863,11 +863,14 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
               '#results .warning-block, #postCalcContent .warning-block'
             )].map(el => {
               /* first sentence up to <br> (or colon) is the “title” */
-              const raw   = el.innerText.replace(/\u2022/g, '•').trim();
-              const [head, ...rest] = raw.split('\n');
+              // Keep original HTML so the PDF helper can see <li> tags or bullets.
+              const rawHTML = el.innerHTML.trim();
+              const head = el.querySelector('strong')
+                           ? el.querySelector('strong').innerText.trim()
+                           : el.innerText.split('\n')[0].trim();
               return {
                 title  : head.replace(/^\s*⚠️|⛔\s*/,'').trim(),
-                body   : rest.join('\n').trim(),
+                body   : rawHTML,
                 danger : el.classList.contains('danger')
               };
             });


### PR DESCRIPTION
## Summary
- keep warning block HTML instead of plain text so pdf generator can preserve bullet formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a6b1967c8333bf8136670165fad5