### PR TITLE
Fix htmlToPlain bullet whitespace

### DIFF
--- a/pdfWarningHelpers.js
+++ b/pdfWarningHelpers.js
@@ -37,8 +37,9 @@ function htmlToPlain(html) {
     // 4. Any other tag ⇒ single space (keeps words apart)
     .replace(/<[^>]+>/g, ' ')
 
-    // 5. Collapse multiple spaces / NBSP
-    .replace(/[\u00A0\s]{2,}/g, ' ')
+    // 5. Collapse multiple ordinary or non-breaking spaces
+    //    (leave new-lines intact so each bullet starts on its own line)
+    .replace(/[ \u00A0]{2,}/g, ' ')
     .trim();
 }
 


### PR DESCRIPTION
## Summary
- keep newlines when collapsing whitespace in `htmlToPlain`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6848ab2f19bc83338b9e021182ef6963