### PR TITLE
Fix jsPDF ReferenceError

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -943,10 +943,14 @@ function generatePDF() {
   const ACCENT_GREEN = '#00ff88';
   const ACCENT_CYAN  = '#0099ff';
   const COVER_GOLD   = '#BBA26F';
-  doc.addFileToVFS("CormorantGaramond-Bold-normal.ttf", cormorantBase64);
-  doc.addFont("CormorantGaramond-Bold-normal.ttf", "CormorantGaramond", "normal");
 
-  const doc   = new jspdf.jsPDF({ unit: 'pt', format: 'a4' });
+  // 1️⃣  Create the jsPDF instance *first*
+  const doc = new jspdf.jsPDF({ unit: 'pt', format: 'a4' });
+
+  // 2️⃣  Embed Cormorant Garamond into this instance
+  doc.addFileToVFS("CormorantGaramond-Bold-normal.ttf", cormorantBase64);
+  doc.addFont     ("CormorantGaramond-Bold-normal.ttf", "CormorantGaramond", "normal");
+
   const pageW = doc.internal.pageSize.getWidth();
   const pageH = doc.internal.pageSize.getHeight();
 


### PR DESCRIPTION
## Summary
- fix variable order in `generatePDF` so `doc` is defined before use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850688e04348333b38932c07e37390c