### PR TITLE
Implement wizard workflow with profile store

### DIFF
--- a/consentModal.js
+++ b/consentModal.js
@@ -1,0 +1,29 @@
+import { profile } from "./profile.js";
+export function showConsent(pdfUrl) {
+  return new Promise(res=>{
+    const overlay=document.createElement("div");
+    overlay.className="modal";
+    overlay.innerHTML=`<div class="wizard-card" style="max-width:460px">
+      <h2>Want a personalised second opinion?</h2>
+      <p>Share these results with a vetted Irish financial adviser in one click. They’ll review your numbers and offer a free 15-minute call.</p>
+      <p><strong>Why we need your OK:</strong> To protect your privacy (GDPR) we only pass your answers with explicit consent. You can revoke at any time.</p>
+      <label><input type="checkbox" id="consentChk"> Yes—securely send my data</label>
+      <div style="margin-top:1rem; display:flex; gap:1rem">
+        <button id="cNo">Not now</button>
+        <button id="cYes" disabled>Share & Continue</button>
+      </div>
+      <small>Encrypted, EU-hosted, auto-deleted after 90 days.</small>
+    </div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#consentChk').onchange=e=>{
+      overlay.querySelector('#cYes').disabled=!e.target.checked;
+    };
+    overlay.querySelector('#cNo').onclick=()=>{document.body.removeChild(overlay);res(false);};
+    overlay.querySelector('#cYes').onclick=()=>{
+      fetch("/api/shareWithAdviser",{method:"POST",headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({profile,pdfUrl})}).finally(()=>{
+          document.body.removeChild(overlay);res(true);
+      });
+    };
+  });
+}

--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -137,6 +137,13 @@
       background: rgba(0, 0, 0, .7); display: flex;
       align-items: center; justify-content: center; z-index: 9999;
     }
+    .modal.hidden{ display:none }
+    .wizard-card{ max-width:420px; border-radius:16px; padding:2rem; background:#2a2a2a }
+    .wizard-controls{ display:flex; justify-content:space-between; margin-top:1rem }
+    .edit{cursor:pointer;margin-left:.4rem}
+    #wizDots{ text-align:center; margin-top:1rem }
+    #wizDots .dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:#555;margin:0 3px}
+    #wizDots .dot.active{background:#00ff88}
     .modal-content {
       background: #2a2a2a; border-radius: 16px;
       padding: 2rem 2.5rem; max-width: 420px; width: 90%;
@@ -197,6 +204,7 @@ canvas {
     <div class="card">
       <h1>F*ck You Money Calculator</h1>
 
+      <div id="legacyForm" style="display:none">
       <form id="fyf-form" autocomplete="off">
         <div class="form-group">
           <label for="grossIncome">Gross annual income (€)</label>
@@ -300,6 +308,7 @@ canvas {
 
         <button type="submit">Calculate</button>
       </form>
+      </div>
 
        <div id="results"></div>
     <div id="chart-container">
@@ -398,7 +407,6 @@ canvas {
          ────────────────────────────────────────────────────────── -->
       <script type="module">
         import { drawBanner, getBannerHeight } from './pdfWarningHelpers.js';
-        import cormorantBase64 from "./CormorantGaramond-Bold-normal.js";
         const setHTML = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML = html; };
         const CPI = 0.023;
         const STATE_PENSION = 15044;
@@ -640,7 +648,17 @@ canvas {
                 </div>`;
             }
 
-            setHTML('results', resultHTML + earlyWarning);
+            latestRun = gatherData(reqCap, retirementYear, sftWarningStripped);
+            const rows = Object.entries(latestRun.inputs)
+              .map(([k,v])=>{
+                const label = LABEL_MAP[k] ?? k;
+                let val = v;
+                if (typeof v === 'boolean') val = fmtBool(v);
+                else if (k.toLowerCase().includes('income') || k==='dbPension') val = fmtEuro(+v||0);
+                return `<tr><td>${label}</td><td>${val}</td><td><span class="edit" onclick="wizard.open('${k}')">✏️</span></td></tr>`;
+              }).join('');
+            const tableHTML = `<table class="assumptions-table"><tbody>${rows}</tbody></table>`;
+            setHTML('results', resultHTML + earlyWarning + tableHTML);
 
 
             // ─── Build cash-flow & balance arrays ───────────────────────────────
@@ -833,8 +851,6 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
    'cashflow-caption',
   'The bars show how your annual income needs are met from different sources after retirement.<br>Green = pension withdrawals; Blue = State-pension / rent / DB; White line = total income need.'
   );
-
-            latestRun = gatherData(reqCap, retirementYear, sftWarningStripped);
 
             function captureCharts () {
               const balCan = balanceChart.canvas,
@@ -1156,10 +1172,26 @@ function generatePDF() {
   addFooter(pageNo);
 
   doc.save('planéir_report.pdf');
+  const pdfUrl = doc.output('bloburl');
+  import('./consentModal.js').then(m=>m.showConsent(pdfUrl));
 }
 
 </script>
     </div>
+    <!-- Wizard overlay -->
+    <div id="wizardModal" class="modal hidden">
+      <div class="wizard-card">
+        <div id="wizardStepContainer"></div>
+        <div class="wizard-controls">
+          <button id="wizBack">Back</button>
+          <button id="wizNext">Next</button>
+        </div>
+        <div id="wizDots"></div>
+      </div>
+    </div>
   </div>
+  <script type="module" src="./profile.js"></script>
+  <script type="module" src="./wizard.js"></script>
+  <script type="module" src="./consentModal.js"></script>
 </body>
 </html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,4 @@
+export const profile = JSON.parse(localStorage.getItem("pp_profile") || "{}");
+export function saveProfile() {
+  localStorage.setItem("pp_profile", JSON.stringify(profile));
+}


### PR DESCRIPTION
## Summary
- hide the old FYF form and add stepper wizard markup
- create `profile.js` for persistent profile answers
- build `wizard.js` to render question steps and submit legacy form
- prompt for adviser consent after PDF generation
- style modal wizard and dots
- add edit buttons in results table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685076adaae08333aa93eb2ccc5b51f9