### PR TITLE
Fix early-warning markup

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -614,7 +614,7 @@ canvas {
             if (retireAge < 50) {
               earlyWarning = `
                 <div class="warning-block danger">
-                  ⛔ Retiring Before Age 50<br>
+                  ⛔ <strong>Retiring Before Age 50</strong><br><br>
                   Under Irish Revenue rules, pensions cannot be accessed before age 50, except in rare cases such as ill-health retirement.<br>
                   These projections are illustrative only — professional guidance is strongly recommended.
                 </div>`;
@@ -622,7 +622,7 @@ canvas {
             else if (retireAge < 60) {
               earlyWarning = `
                 <div class="warning-block">
-                  ⚠️ Retiring Between Age 50–59<br>
+                  ⚠️ <strong>Retiring Between Age 50–59</strong><br><br>
                   Access to pension benefits before the usual retirement age is only possible in limited cases.<br><br>
                   Typical Normal Retirement Ages (NRAs) are:<br>
                   60–70 for most occupational pensions<br>
@@ -640,7 +640,7 @@ canvas {
             else if (retireAge < 75) {
               earlyWarning = `
                 <div class="warning-block">
-                  ⚠️ Retirement Age Over 70 (Occupational Pensions &amp; PRBs)<br>
+                  ⚠️ <strong>Retirement Age Over 70 (Occupational Pensions &amp; PRBs)</strong><br><br>
                   Most occupational pensions and Personal Retirement Bonds (PRBs) must be drawn down by age 70 under Irish Revenue rules.<br>
                   If your selected retirement age is over 70, please be aware this may not be allowed for those pension types.<br><br>
                   Note: The exception to this is PRSAs, which can remain unretired until age 75.<br><br>
@@ -650,7 +650,7 @@ canvas {
             else {
               earlyWarning = `
                 <div class="warning-block danger">
-                  ⛔ Retirement Age 75 and Over<br>
+                  ⛔ <strong>Retirement Age 75 and Over</strong><br><br>
                   Under Irish Revenue rules, all pensions — including PRSAs — must be accessed by age 75.<br>
                   If benefits are not drawn down by this age, the pension is automatically deemed to vest, and the full value may be treated as taxable income.<br>
                   These projections are illustrative only — professional guidance is strongly recommended.
@@ -897,6 +897,10 @@ cashflowChart = new Chart(document.getElementById('cashflowChart'), {
               // --- clone element so we can delete the <strong> headline --------------
               const clone = el.cloneNode(true);
               if (strong) clone.removeChild(clone.querySelector('strong'));
+              else {
+                // strip the first text line + following <br>
+                clone.innerHTML = clone.innerHTML.replace(/^[\s\S]*?<br\s*\/?>/, '');
+              }
 
               // remove the leading emoji + any whitespace that might precede content
               const bodyHTML = clone.innerHTML


### PR DESCRIPTION
## Summary
- emphasize the dynamic early warning titles with `<strong>` tags and add a blank line after each
- remove the duplicate warning titles when capturing banners for PDF output

## Testing
- `node --check pdfWarningHelpers.js`

------
https://chatgpt.com/codex/tasks/task_e_685534882d108333994016b08a8aa8a6