### PR TITLE
Add wizard & PDF export to pension projection tool

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -64,6 +64,13 @@
   position:absolute;right:1.2rem;top:0.8rem;font-size:1.8rem;cursor:pointer;color:#fff;
 }
 .modal h2 {margin-top:0;color:#ff5c5c}
+/* wizard specific */
+.wizard-card{ max-width:420px; border-radius:16px; padding:2rem; background:#2a2a2a }
+#wizardModal h3 { font-weight:600; font-size:1.1rem; color:#fff; }
+.wizard-controls{ display:flex; justify-content:space-between; margin-top:1rem }
+#wizDots{ text-align:center; margin-top:1rem }
+#wizDots .dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:#555;margin:0 3px}
+#wizDots .dot.active{background:#00ff88}
 /* ─── Growth-profile cards ─────────────────────────── */
 .risk-options{
   display:grid;
@@ -223,7 +230,35 @@
           <canvas id="contribChart"></canvas>
         </div>
       </div>
+
+      <div id="postCalcContent" style="display:none;">
+        <button id="downloadPdf" style="margin-top:1rem">Download PDF report</button>
+
+        <div class="warning-block">
+          ⚠️ <strong>Important Notice</strong><br><br>
+          This calculator does not include mandatory pension withdrawals (imputed distributions), required annually by Revenue rules from age 61:<br><br>
+          <ul style="margin-top:0; margin-bottom:1rem; padding-left:1.2rem;">
+            <li>Age 61–70: 4% per year</li>
+            <li>Age 71+: 5% per year</li>
+            <li>Age 61+ (if pension exceeds €2 million): 6% per year</li>
+          </ul>
+          In practice, a prudent investor would typically reinvest any surplus amounts withdrawn beyond their spending needs—though these reinvestments would occur outside the pension structure, under different tax conditions.<br><br>
+          Despite this limitation, the calculator’s projections remain a reasonable reflection of expected retirement outcomes.<br><br>
+          <em>For personalised analysis, please consult a qualified financial adviser.</em>
+        </div>
+      </div>
+
       <div id="console" class="error"></div>
+
+      <details id="assumptions" style="margin-top:1rem">
+        <summary>Assumptions</summary>
+        <table class="assumptions-table" id="assumptions-table">
+          <thead>
+            <tr><th>Assumption</th><th>Value</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </details>
     </div>
   </div>
 <!-- This is the modal box that appears if the pension exceeds the SFT -->
@@ -241,9 +276,26 @@
   </div>
 </div>
   
-<script src="./pensionProjection.js"></script>
-
-
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.0/dist/jspdf.plugin.autotable.min.js"></script>
+  <script type="module" src="pdfWarningHelpers.js"></script>
+  <script src="./syncMinAge.js"></script>
+  <script type="module" src="./pensionProjection.js"></script>
+  <!-- Wizard overlay -->
+  <div id="wizardModal" class="modal hidden">
+    <div class="wizard-card">
+      <h3 id="wizProgress" style="margin:0 0 1rem 0;text-align:center"></h3>
+      <div id="wizardStepContainer"></div>
+      <div class="wizard-controls">
+        <button id="wizBack">Back</button>
+        <button id="wizNext">Next</button>
+      </div>
+      <div id="wizDots"></div>
+    </div>
+  </div>
+  <script type="module" src="./profile.js"></script>
+  <script type="module" src="./pensionWizard.js"></script>
+  <script type="module" src="./consentModal.js"></script>
 </body>
 </html>
 

--- a/pensionWizard.js
+++ b/pensionWizard.js
@@ -1,0 +1,154 @@
+// Wizard for pension projection tool
+import { profile, saveProfile } from './profile.js';
+
+const steps = [
+  { id: 'dob', q: "What's your date of birth?", type: 'date' },
+  { id: 'salary', q: 'Gross annual salary (€)?', type: 'number', min: 0 },
+  { id: 'currentValue', q: 'Current pension value (€)?', type: 'number', min: 0 },
+  { id: 'personalContrib', q: 'Your annual contribution (€)', type: 'number', min: 0, optional: true },
+  { id: 'personalPct', q: 'or % of salary if no € amount', type: 'number', min: 0, max: 100, step: 0.1, optional: true },
+  { id: 'employerContrib', q: 'Employer annual contribution (€)', type: 'number', min: 0, optional: true },
+  { id: 'employerPct', q: 'or % of salary if no € amount', type: 'number', min: 0, max: 100, step: 0.1, optional: true },
+  { id: 'retireAge', q: 'Desired retirement age?', type: 'number', min: 50, max: 75 },
+  { id: 'growth', q: 'Choose a growth profile', type: 'riskCard' }
+];
+
+const modal = document.getElementById('wizardModal');
+const stepContainer = document.getElementById('wizardStepContainer');
+const btnBack = document.getElementById('wizBack');
+const btnNext = document.getElementById('wizNext');
+const dots = document.getElementById('wizDots');
+const progEl = document.getElementById('wizProgress');
+let visibleSteps = [];
+let cur = 0;
+
+function btn(txt) {
+  const b = document.createElement('button');
+  b.textContent = txt;
+  return b;
+}
+
+function refresh() {
+  visibleSteps = steps; // no conditional visibility
+}
+
+function buildInput(step) {
+  let input;
+  if (step.type === 'boolean') {
+    const ctr = document.createElement('div');
+    const yes = btn('Yes'), no = btn('No');
+    yes.onclick = () => { profile[step.id] = true; saveProfile(); next(); };
+    no.onclick = () => { profile[step.id] = false; saveProfile(); next(); };
+    ctr.append(yes, no);
+    btnNext.style.visibility = 'hidden';
+    input = ctr;
+  } else if (step.type === 'riskCard') {
+    const opts = [
+      { val: 0.04, title: 'Low risk', desc: '≈ 30% stocks / 70% bonds<br>≈ 4% p.a.' },
+      { val: 0.05, title: 'Balanced', desc: '≈ 50% stocks / 50% bonds<br>≈ 5% p.a.' },
+      { val: 0.06, title: 'High risk', desc: '≈ 70% stocks / 30% bonds<br>≈ 6% p.a.' },
+      { val: 0.07, title: 'Very-high', desc: '100% stocks<br>≈ 7% p.a.' }
+    ];
+    const wrap = document.createElement('div');
+    wrap.className = 'risk-options';
+    opts.forEach(o => {
+      const card = document.createElement('div');
+      card.className = 'risk-card';
+      card.innerHTML = `<span class="risk-title">${o.title}</span>` +
+                       `<span class="risk-desc">${o.desc}</span>`;
+      card.onclick = () => {
+        wrap.querySelectorAll('.risk-card.selected').forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        profile.growth = o.val; saveProfile(); btnNext.disabled = false;
+      };
+      if (profile.growth === o.val) card.classList.add('selected');
+      wrap.appendChild(card);
+    });
+    btnNext.style.visibility = 'visible';
+    btnNext.disabled = !profile.growth;
+    input = wrap;
+  } else {
+    btnNext.style.visibility = 'visible';
+    if (step.type === 'number' || step.type === 'date') {
+      input = document.createElement('input');
+      input.type = step.type;
+      if (step.min != null) input.min = step.min;
+      if (step.max != null) input.max = step.max;
+      if (step.step != null) input.step = step.step;
+      input.value = profile[step.id] ?? '';
+    }
+  }
+  input.id = 'wizInput';
+  return input;
+}
+
+function render() {
+  refresh();
+  if (cur < 0) cur = 0;
+  if (cur >= visibleSteps.length) { finalize(); return; }
+  const step = visibleSteps[cur];
+  progEl.textContent = `Step ${cur + 1} of ${visibleSteps.length}`;
+  stepContainer.innerHTML = '';
+  const q = document.createElement('p');
+  q.textContent = step.q;
+  stepContainer.appendChild(q);
+  stepContainer.appendChild(buildInput(step));
+  btnBack.style.display = cur === 0 ? 'none' : '';
+  btnNext.textContent = cur === visibleSteps.length - 1 ? 'Submit' : 'Next';
+  dots.innerHTML = visibleSteps.map((_, i) => `<span class="dot${i === cur ? ' active' : ''}"></span>`).join('');
+}
+
+function getValue(step) {
+  const el = document.getElementById('wizInput');
+  if (step.type === 'boolean') return profile[step.id] ?? null;
+  if (step.type === 'number') return el.value ? +el.value : '';
+  return el.value;
+}
+
+function valid(step, val) {
+  if (step.optional && (val === null || val === '')) return true;
+  if (step.type === 'number') {
+    if (val === '' || isNaN(val)) return false;
+    if (step.min != null && val < step.min) return false;
+    if (step.max != null && val > step.max) return false;
+  } else if (step.type === 'date') {
+    if (!val) return false;
+  } else if (step.type === 'boolean') {
+    if (val === null) return false;
+  }
+  return true;
+}
+
+function next() {
+  refresh();
+  const step = visibleSteps[cur];
+  const val = step.type === 'boolean' ? profile[step.id] : getValue(step);
+  if (!valid(step, val)) return;
+  profile[step.id] = val; saveProfile();
+  cur++; render();
+}
+
+function back() { cur--; render(); }
+
+btnNext.onclick = next;
+btnBack.onclick = back;
+
+function copyToForm() {
+  steps.forEach(s => {
+    const field = document.getElementById(s.id);
+    if (!field) return;
+    const val = profile[s.id];
+    field.value = val ?? '';
+  });
+}
+
+function finalize() {
+  modal.classList.add('hidden');
+  copyToForm();
+  document.getElementById('proj-form').requestSubmit();
+}
+
+export const wizard = { open(id) { refresh(); cur = id ? steps.findIndex(s => s.id === id) : 0; if (cur < 0) cur = 0; modal.classList.remove('hidden'); render(); } };
+window.wizard = wizard;
+
+document.addEventListener('DOMContentLoaded', () => wizard.open());


### PR DESCRIPTION
## Summary
- bring Pension Projection tool inline with FY Money Calculator
- add wizard-style input flow
- implement PDF report generation with assumptions page
- display warnings and charts similar to FY Money Calculator

## Testing
- `node -e "import('./pensionProjection.js').then(()=>console.log('loaded')).catch(e=>console.error(e.message))"`

------
https://chatgpt.com/codex/tasks/task_e_685d2b013d40833391f53652e76438ea