### PR TITLE
Improve contribution fields

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -16,6 +16,7 @@
     .card{width:100%;max-width:640px;background:#2a2a2a;border-radius:16px;box-shadow:0 0 25px rgba(0,255,136,.25);padding:2rem}
     .form-group{margin-bottom:1rem}
     label{display:block;margin-bottom:.4rem;font-weight:600}
+    .sub-label{margin-top:.6rem}
     input[type=number],input[type=date]{width:100%;padding:.55rem .7rem;border:none;border-radius:8px;background:#404040;color:#fff}
     input::placeholder{color:#aaa}
     .two-col{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
@@ -148,26 +149,18 @@
           <input type="number" id="currentValue" required />
         </div>
 
-        <div class="two-col">
-          <div class="form-group">
-            <label for="personalContrib">Your annual contribution (€)</label>
-            <input type="number" id="personalContrib" placeholder="Leave blank if % instead" />
-          </div>
-          <div class="form-group">
-            <label for="personalPct">% of salary</label>
-            <input type="number" id="personalPct" step="0.1" placeholder="Leave blank if € used" />
-          </div>
+        <div class="form-group">
+          <label for="personalContrib">Your annual pension contribution (€)</label>
+          <input type="number" id="personalContrib" placeholder="Leave blank if using % of salary" />
+          <label for="personalPct" class="sub-label">% of salary</label>
+          <input type="number" id="personalPct" step="0.1" placeholder="Leave blank if € used" />
         </div>
 
-        <div class="two-col">
-          <div class="form-group">
-            <label for="employerContrib">Employer annual contribution (€)</label>
-            <input type="number" id="employerContrib" placeholder="Leave blank if % instead" />
-          </div>
-          <div class="form-group">
-            <label for="employerPct">% of salary</label>
-            <input type="number" id="employerPct" step="0.1" placeholder="Leave blank if € used" />
-          </div>
+        <div class="form-group">
+          <label for="employerContrib">Employer annual contribution (€)</label>
+          <input type="number" id="employerContrib" placeholder="Leave blank if using % of salary" />
+          <label for="employerPct" class="sub-label">% of salary</label>
+          <input type="number" id="employerPct" step="0.1" placeholder="Leave blank if € used" />
         </div>
 
         <div class="form-group">

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -45,7 +45,7 @@ const ASSUMPTIONS_TABLE = [
 const LABEL_MAP = {
   salary: 'Gross salary (€)',
   currentValue: 'Current pension value (€)',
-  personalContrib: 'Personal contribution (€)',
+  personalContrib: 'Your annual pension contribution (€)',
   personalPct: 'Personal contribution (%)',
   employerContrib: 'Employer contribution (€)',
   employerPct: 'Employer contribution (%)',


### PR DESCRIPTION
## Summary
- stack the euro and percent fields for personal and employer contributions
- update label map to match the new text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f42efc083339efec3b8ad084988