### PR TITLE
Ensure wizard overlay hidden initially

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -57,6 +57,7 @@
   background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;
   z-index:9999;
 }
+.modal.hidden { display: none; }
 .modal-content {
   background:#2a2a2a;border-radius:16px;padding:2rem 2.5rem;max-width:420px;width:90%;
   text-align:center;box-shadow:0 0 25px rgba(255,0,0,.4);position:relative;


### PR DESCRIPTION
## Summary
- add `.modal.hidden` class to hide the wizard overlay by default

## Testing
- `grep -n modal.hidden -n pension-projection.html`

------
https://chatgpt.com/codex/tasks/task_e_686016a9149c8333955c87f63be59db2