### PR TITLE
Fix wizard validation for contribution pair

### DIFF
--- a/pensionWizard.js
+++ b/pensionWizard.js
@@ -147,6 +147,11 @@ function getValue(step) {
 
 function valid(step, val) {
   if (step.type === 'pair') {
+    const filled = step.fields.filter(f => {
+      const v = val[f.id];
+      return v !== '' && v !== null;
+    });
+    if (filled.length > 1) return false;
     return step.fields.every(f => {
       const v = val[f.id];
       if (f.optional && (v === '' || v === null)) return true;


### PR DESCRIPTION
## Summary
- prevent wizard from accepting a value for both contribution fields

## Testing
- `node --check pensionWizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68601763842883339be236cfb450020c