### PR TITLE
fix wizard growth selection

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -102,6 +102,11 @@
   border-color:#00ff88;
   box-shadow:0 0 12px rgba(0,255,136,.6);
 }
+/* Highlight cards chosen in the wizard */
+.risk-card.selected {
+  border-color:#00ff88;
+  box-shadow:0 0 12px rgba(0,255,136,.6);
+}
 
 /* Keyboard focus (accessibility) */
 .risk-options input[type=radio]:focus + .risk-card{

--- a/pensionWizard.js
+++ b/pensionWizard.js
@@ -141,6 +141,7 @@ function getValue(step) {
   }
   const el = document.getElementById('wizInput');
   if (step.type === 'boolean') return profile[step.id] ?? null;
+  if (step.type === 'riskCard') return profile[step.id];
   if (step.type === 'number') return el.value ? +el.value : '';
   return el.value;
 }
@@ -181,9 +182,10 @@ function next() {
   if (step.type === 'pair') {
     step.fields.forEach(f => { profile[f.id] = val[f.id]; });
     saveProfile();
-  } else {
+  } else if (step.type !== 'riskCard') {
     profile[step.id] = val; saveProfile();
   }
+  // riskCard value already stored on selection
   cur++; render();
 }
 
@@ -201,6 +203,11 @@ function copyToForm() {
         const val = profile[f.id];
         field.value = val ?? '';
       });
+    } else if (s.type === 'riskCard') {
+      const val = profile[s.id];
+      if (val == null) return;
+      const field = document.querySelector(`input[name="${s.id}"][value="${val}"]`);
+      if (field) field.checked = true;
     } else {
       const field = document.getElementById(s.id);
       if (!field) return;

--- a/wizard.js
+++ b/wizard.js
@@ -117,6 +117,7 @@ function render(){
 function getValue(step){
   const el=document.getElementById('wizInput');
   if(step.type==='boolean') return profile[step.id]??null;
+  if(step.type==='riskCard') return profile[step.id];
   if(step.type==='number') return el.value?+el.value:'';
   return el.value;
 }
@@ -140,7 +141,12 @@ function next(){
   const step=visibleSteps[cur];
   const val = step.type==='boolean' ? profile[step.id] : getValue(step);
   if(!valid(step,val)) return;
-  profile[step.id]=val; saveProfile();
+  if(step.type==='pair'){
+    step.fields.forEach(f=>{ profile[f.id]=val[f.id]; });
+    saveProfile();
+  }else if(step.type!=='riskCard'){
+    profile[step.id]=val; saveProfile();
+  }
   cur++;
   render();
 }
@@ -155,6 +161,13 @@ btnBack.onclick=back;
 
 function copyToForm(){
   steps.forEach(s=>{
+    if(s.type==='riskCard'){
+      const val=profile[s.id];
+      if(val==null) return;
+      const field=document.querySelector(`input[name="${s.id}"][value="${val}"]`);
+      if(field) field.checked=true;
+      return;
+    }
     const field=document.getElementById(s.id);
     if(!field) return;
     const val=profile[s.id];


### PR DESCRIPTION
## Summary
- preserve selected growth rate in the pension and FYM wizards
- set the radio buttons correctly when the wizard closes
- add CSS for wizard-selected cards

## Testing
- `node --check pensionWizard.js`
- `node --check wizard.js`
- `node --check pensionProjection.js`
- `node --check fyMoneyCalculator.js`


------
https://chatgpt.com/codex/tasks/task_e_6860188f37a08333b246cfd8b73c0208