### PR TITLE
Improve pension tool UI

### DIFF
--- a/pension-projection.html
+++ b/pension-projection.html
@@ -70,6 +70,7 @@
 .wizard-card{ max-width:420px; border-radius:16px; padding:2rem; background:#2a2a2a }
 #wizardModal h3 { font-weight:600; font-size:1.1rem; color:#fff; }
 .wizard-controls{ display:flex; justify-content:space-between; margin-top:1rem }
+.edit{cursor:pointer;margin-left:.4rem}
 #wizDots{ text-align:center; margin-top:1rem }
 #wizDots .dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:#555;margin:0 3px}
 #wizDots .dot.active{background:#00ff88}
@@ -144,6 +145,7 @@
     <div class="card">
       <h1>Pension Projection Tool</h1>
 
+      <div id="legacyForm" style="display:none">
       <form id="proj-form" autocomplete="off">
         <div class="form-group">
           <label for="salary">Gross salary (€) <small>(max €115 000 is used in calculations)</small></label>
@@ -218,6 +220,7 @@
 
         <button type="submit">Project value</button>
       </form>
+      </div>
 
       <div id="results"></div>
       <div id="chart-container">

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -524,6 +524,21 @@ if (projValue > sftLimit) {
       .replace(/<\/?[^>]+>/g, '');
     latestRun = gatherData(projValue, retirementYear, sftPlain);
 
+    const rows = Object.entries(latestRun.inputs)
+      .map(([k,v])=>{
+        const label = LABEL_MAP[k] ?? k;
+        let val = v;
+        if (k === 'salary' || k === 'currentValue' ||
+            k === 'personalContrib' || k === 'employerContrib')
+          val = fmtEuro(+v || 0);
+        else if (k.endsWith('Pct') || k === 'growth')
+          val = (+(v)*100).toFixed(0) + ' %';
+        return `<tr><td>${label}</td><td>${val}</td>`+
+               `<td><span class="edit" onclick="wizard.open('${k}')">✏️</span></td></tr>`;
+      }).join('');
+    const tableHTML = `<table class="assumptions-table"><tbody>${rows}</tbody></table>`;
+    document.getElementById('results').innerHTML += tableHTML;
+
     latestRun.warningBlocks = [...document.querySelectorAll('#results .warning-block, #postCalcContent .warning-block')].map(el => {
       const strong = el.querySelector('strong');
       const headText = strong ? strong.innerText.trim() : el.innerText.split('\n')[0].trim();


### PR DESCRIPTION
## Summary
- hide the old pension projection form
- show a compact table of inputs after running calculations
- allow easy editing via wizard using edit icons

## Testing
- `node --check pensionProjection.js`

------
https://chatgpt.com/codex/tasks/task_e_68601a50c8c4833392de8294fa6fa19e