### PR TITLE
Fix pension charts error on first run

### DIFF
--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -518,11 +518,11 @@ if (projValue > sftLimit) {
       return { inputs, outputs, assumptions: ASSUMPTIONS_TABLE };
     }
 
-    captureCharts();
     const sftPlain = sftWarningHTML
       .replace(/<br\s*\/?>/gi, ' ')
       .replace(/<\/?[^>]+>/g, '');
     latestRun = gatherData(projValue, retirementYear, sftPlain);
+    captureCharts();
 
     const rows = Object.entries(latestRun.inputs)
       .map(([k,v])=>{


### PR DESCRIPTION
## Summary
- fix order of `gatherData` and `captureCharts` so `latestRun` isn't null

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68601c6af9808333b292f0e4128216e2