### PR TITLE
Fix percent display in projection table

### DIFF
--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -536,10 +536,13 @@ if (projValue > sftLimit) {
         const label = LABEL_MAP[k] ?? k;
         let val = v;
         if (k === 'salary' || k === 'currentValue' ||
-            k === 'personalContrib' || k === 'employerContrib')
+            k === 'personalContrib' || k === 'employerContrib') {
           val = fmtEuro(+v || 0);
-        else if (k.endsWith('Pct') || k === 'growth')
-          val = (+(v)*100).toFixed(0) + ' %';
+        } else if (k === 'growth') {
+          val = (+(v) * 100).toFixed(0) + ' %';
+        } else if (k === 'personalPct' || k === 'employerPct') {
+          val = (+v).toFixed(1).replace(/\.0$/, '') + ' %';
+        }
         const step = stepMap[k] ?? k;
         return `<tr><td>${label}</td><td>${val}</td>`+
                `<td><span class="edit" onclick="wizard.open('${step}')">✏️</span></td></tr>`;


### PR DESCRIPTION
## Summary
- correct personal and employer contribution percent display

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_686020fd0378833398c1f0c9a88a8662