### PR TITLE
Adjust PRB retirement age in warnings

### DIFF
--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -209,8 +209,8 @@ These projections are illustrative only — professional guidance is strongly re
 ⚠️ <strong>Retiring Between Age 50–59</strong><br><br>
 Access to pension benefits before the usual retirement age is only possible in limited cases.<br><br>
 Typical Normal Retirement Ages (NRAs) are:<br>
-60–70 for most occupational pensions<br>
-60–75 for PRSAs and Personal Retirement Bonds (PRBs)<br><br>
+60–70 for most occupational pensions and Personal Retirement Bonds (PRBs)<br>
+60–75 for PRSAs<br><br>
 Early access (from age 50) may be possible only if certain Revenue conditions are met — e.g.:<br>
 You’ve left employment linked to the pension<br>
 You’re a proprietary director who fully severs ties with the sponsoring company<br><br>

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -450,8 +450,8 @@ if (retireAge < 50) {
       ⚠️ <strong>Retiring Between Age 50–59</strong><br><br>
       Access to pension benefits before the usual retirement age is only possible in limited cases.<br><br>
       Typical Normal Retirement Ages (NRAs) are:<br>
-      60–70 for most occupational pensions<br>
-      60–75 for PRSAs and Personal Retirement Bonds (PRBs)<br><br>
+      60–70 for most occupational pensions and Personal Retirement Bonds (PRBs)<br>
+      60–75 for PRSAs<br><br>
       Early access (from age 50) may be possible only if certain Revenue conditions are met — e.g.:<br>
       You’ve left employment linked to the pension<br>
       You’re a proprietary director who fully severs ties with the sponsoring company<br><br>


### PR DESCRIPTION
## Summary
- update the under‑60 retirement warning text so Personal Retirement Bonds are grouped with occupational pensions

## Testing
- `node --check fyMoneyCalculator.js`
- `node --check pensionProjection.js`


------
https://chatgpt.com/codex/tasks/task_e_686026ff10cc833392680250a95beed2