### PR TITLE
Fix PDF chart capture

### DIFF
--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -229,6 +229,7 @@ function drawChart() {
     type: 'line',
     data: { labels, datasets },
     options: {
+      animation: false,
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
@@ -340,6 +341,7 @@ function drawContribChart(showMax) {
       ]
     },
     options: {
+      animation: false,
       responsive: true,
       maintainAspectRatio: false,
       plugins: {


### PR DESCRIPTION
## Summary
- disable Chart.js animations when rendering growth and contribution charts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686023fed1e88333a8bcaf34d1f8be76