### PR TITLE
Add warning about SFT assumptions for 2030+ retirements

### DIFF
--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -159,6 +159,17 @@ reqCap += net / Math.pow(1 + gRate, t + 1);
   const sftLimitSingle = sftForYear(retirementYear);
   const sftLimitCombined = includePartnerSP ? sftLimitSingle * 2 : sftLimitSingle;
 
+  let sftAssumpWarning = '';
+  if (retirementYear >= 2030) {
+    sftAssumpWarning = `
+      <div class="warning-block">
+        ⚠️ <strong>Important Warning – Standard Fund Threshold (SFT) Assumptions</strong><br><br>
+        This pension projection tool uses the Standard Fund Threshold (SFT) figures as published by the Irish Government for each year up to and including 2029. These are the most recent years for which official, fixed SFT values have been confirmed.<br><br>
+        While the Government has indicated that the SFT will increase in line with wage inflation beyond 2029, no definitive figures or formulae have been published to date. As a result, this tool does not project future increases to the SFT beyond 2029, as doing so would require speculative or unreliable assumptions.<br><br>
+        Users should be aware that actual SFT limits post-2029 may differ significantly depending on future policy decisions and economic conditions. We recommend consulting a qualified financial advisor for guidance specific to your circumstances.
+      </div>`;
+  }
+
   if (reqCap > sftLimitCombined) {
     const msg = includePartnerSP
 ? `The amount you and your partner require (€${reqCap.toLocaleString()}) is above the combined Standard Fund Threshold for ${retirementYear} (2 × €${sftLimitSingle.toLocaleString()} = €${sftLimitCombined.toLocaleString()}).<br><br>Note: the maximum that can be held in a single pension tax-efficiently in ${retirementYear} is €${sftLimitSingle.toLocaleString()}.`
@@ -251,7 +262,7 @@ else if (k.toLowerCase().includes('income') || k==='dbPension') val = fmtEuro(+v
 return `<tr><td>${label}</td><td>${val}</td><td><span class="edit" onclick="wizard.open('${k}')">✏️</span></td></tr>`;
     }).join('');
   const tableHTML = `<table class="assumptions-table"><tbody>${rows}</tbody></table>`;
-  setHTML('results', resultHTML + earlyWarning + tableHTML);
+  setHTML('results', resultHTML + earlyWarning + sftAssumpWarning + tableHTML);
 
 
   // ─── Build cash-flow & balance arrays ───────────────────────────────

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -436,6 +436,17 @@ const retirementYear = new Date().getFullYear() + Math.ceil(yearsToRet);
 const sftLimit       = sftForYear(retirementYear);
 sftLimitGlobal = sftLimit;
 
+  let sftAssumpWarning = '';
+  if (retirementYear >= 2030) {
+    sftAssumpWarning = `
+      <div class="warning-block">
+        ⚠️ <strong>Important Warning – Standard Fund Threshold (SFT) Assumptions</strong><br><br>
+        This pension projection tool uses the Standard Fund Threshold (SFT) figures as published by the Irish Government for each year up to and including 2029. These are the most recent years for which official, fixed SFT values have been confirmed.<br><br>
+        While the Government has indicated that the SFT will increase in line with wage inflation beyond 2029, no definitive figures or formulae have been published to date. As a result, this tool does not project future increases to the SFT beyond 2029, as doing so would require speculative or unreliable assumptions.<br><br>
+        Users should be aware that actual SFT limits post-2029 may differ significantly depending on future policy decisions and economic conditions. We recommend consulting a qualified financial advisor for guidance specific to your circumstances.
+      </div>`;
+  }
+
 let ageWarning = '';
 if (retireAge < 50) {
   ageWarning = `
@@ -492,7 +503,7 @@ const resultsHTML = `
     Projected value at age ${retireAge}:<br>
     <strong>€${projValue.toLocaleString()}</strong>
   </h2>
-` + ageWarning;
+` + ageWarning + sftAssumpWarning;
 
 let sftWarningHTML = '';
 if (projValue > sftLimit) {


### PR DESCRIPTION
## Summary
- show a Standard Fund Threshold assumption warning whenever the retirement year is 2030 or later
- include the warning in both the pension projection and FY money calculator results

## Testing
- `node --check pensionProjection.js`
- `node --check fyMoneyCalculator.js`


------
https://chatgpt.com/codex/tasks/task_e_6860283565f08333b8a498416b558168