### PR TITLE
Fix variable names in PDF helpers

### DIFF
--- a/pdfWarningHelpers.js
+++ b/pdfWarningHelpers.js
@@ -103,15 +103,15 @@ export function drawBanner(doc, warning, x, y, width) {
   doc.roundedRect(x, y, width, h, radius, radius, 'FD');
 
   // Text
-  let cy = y + padding.top;
+  let currY = y + padding.top;
   doc.setTextColor(text);
 
   doc.setFont(undefined, fonts.title.weight).setFontSize(fonts.title.size);
-  doc.text(titleLines, x + padding.side, cy);
-  cy += titleH + padding.gap;
+  doc.text(titleLines, x + padding.side, currY);
+  currY += titleH + padding.gap;
 
   doc.setFont(undefined, fonts.body.weight).setFontSize(fonts.body.size);
-  doc.text(bodyLines, x + padding.side, cy, {
+  doc.text(bodyLines, x + padding.side, currY, {
     lineHeightFactor: lineHeight,
     align: 'left'
   });

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -768,14 +768,14 @@ function generatePDF() {
                       lines1.length*lineH + 4 + lines2.length*lineH + padBottom;
   doc.setFillColor('#222').setDrawColor(ACCENT_CYAN).setLineWidth(2)
      .roundedRect(summaryX, summaryY, summaryW, summaryBoxH, 12, 12, 'FD');
-  let cy = summaryY + padTop;
+  let currY = summaryY + padTop;
   doc.setFontSize(16).setFont(undefined,'bold').setTextColor(ACCENT_CYAN);
-  doc.text('Summary', summaryX + padSide, cy);
-  cy += headingH + gap;
+  doc.text('Summary', summaryX + padSide, currY);
+  currY += headingH + gap;
   doc.setFontSize(12).setFont(undefined,'normal').setTextColor('#fff');
-  doc.text(lines1, summaryX + padSide, cy, {lineHeightFactor:1.4});
-  cy += lines1.length*lineH + 4;
-  doc.text(lines2, summaryX + padSide, cy, {lineHeightFactor:1.4});
+  doc.text(lines1, summaryX + padSide, currY, {lineHeightFactor:1.4});
+  currY += lines1.length*lineH + 4;
+  doc.text(lines2, summaryX + padSide, currY, {lineHeightFactor:1.4});
   summaryY += summaryBoxH;
 
   let rightY = summaryY + 12;


### PR DESCRIPTION
## Summary
- rename `cy` variable to `currY` in the PDF helpers

## Testing
- `node --check pdfWarningHelpers.js`
- `node --check pensionProjection.js`


------
https://chatgpt.com/codex/tasks/task_e_6863dc3e9a7c83338238d2cab1bb6b49