### PR TITLE
Fix summary paragraph spacing

### DIFF
--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -775,7 +775,8 @@ function generatePDF() {
   currY += headingH + gap;
   doc.setFontSize(12).setFont(undefined,'normal').setTextColor('#fff');
   doc.text(lines1, summaryX + padSide, currY, {lineHeightFactor:1.4});
-  currY += lines1.length*summaryLineH + 4;
+  const h1 = doc.getTextDimensions(lines1.join('\n')).h;
+  currY += h1 + 4; // 4-pt gap between paragraphs
   doc.text(lines2, summaryX + padSide, currY, {lineHeightFactor:1.4});
   summaryY += summaryBoxH;
 


### PR DESCRIPTION
## Summary
- measure actual height of first paragraph in summary box
- use measured height to position second paragraph

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863e3d5a7d483339e6e7b702c3b4178