### PR TITLE
Display euro and percent symbols in wizard inputs

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -84,6 +84,12 @@
     }
 
     .error { color: #ff5c5c; margin-top: .5rem }
+    .input-wrap { position: relative; display: inline-block; }
+    .input-wrap.prefix  input { padding-left: 1.6rem; }
+    .input-wrap.suffix  input { padding-right: 1.6rem; }
+    .input-wrap .unit { position: absolute; top: 50%; transform: translateY(-50%); color: #bbb; font-size: 0.9em; pointer-events: none; }
+    .input-wrap.prefix  .unit { left: 0.5rem; }
+    .input-wrap.suffix  .unit { right: 0.5rem; }
 
     .warning-block {
       background: #444;

--- a/pension-projection.html
+++ b/pension-projection.html
@@ -26,6 +26,12 @@
     #results{margin-top:2rem;background:#333;border-radius:12px;padding:1rem 1.2rem}
     #chart-container{margin-top:1.5rem}
     .error{color:#ff5c5c;margin-top:.5rem}
+    .input-wrap { position: relative; display: inline-block; }
+    .input-wrap.prefix  input { padding-left: 1.6rem; }
+    .input-wrap.suffix  input { padding-right: 1.6rem; }
+    .input-wrap .unit { position: absolute; top: 50%; transform: translateY(-50%); color: #bbb; font-size: 0.9em; pointer-events: none; }
+    .input-wrap.prefix  .unit { left: 0.5rem; }
+    .input-wrap.suffix  .unit { right: 0.5rem; }
     .warning-block{
       background:#444;
       border-left:4px solid #ffa500;

--- a/wizard.js
+++ b/wizard.js
@@ -47,6 +47,28 @@ function refresh(){
   steps.forEach(s=>{ if(s.visIf && !s.visIf(profile)) delete profile[s.id]; });
 }
 
+/* builds an <input type=number> wrapped with € or % */
+function unitBox({ id, value = '', min, max, step, unit = '€', side = 'prefix' }) {
+  const wrap = document.createElement('div');
+  wrap.className = `input-wrap ${side}`;
+
+  const inp  = document.createElement('input');
+  inp.type   = 'number';
+  inp.id     = id;
+  if (min  != null) inp.min  = min;
+  if (max  != null) inp.max  = max;
+  if (step != null) inp.step = step;
+  inp.value = value;
+  wrap.appendChild(inp);
+
+  const span = document.createElement('span');
+  span.className   = 'unit';
+  span.textContent = unit;
+  wrap.appendChild(span);
+
+  return wrap;
+}
+
 function buildInput(step){
   let input;
   if(step.type==='boolean'){
@@ -87,7 +109,22 @@ function buildInput(step){
     input=wrap;
   }else{
     btnNext.style.visibility='visible';
-    if(step.type==='number'||step.type==='date'){
+    if(step.id==='incomePercent'){
+      input = unitBox({
+        id:'wizInput',
+        value:profile[step.id]??'',
+        min:step.min, max:step.max, step:step.step,
+        unit:'%', side:'suffix'
+      });
+    }else if(['salary','currentValue','grossIncome','rentalIncome','dbPension',
+              'personalContrib','employerContrib'].includes(step.id)){
+      input = unitBox({
+        id:'wizInput',
+        value:profile[step.id]??'',
+        min:step.min, max:step.max, step:step.step,
+        unit:'€', side:'prefix'
+      });
+    }else if(step.type==='number'||step.type==='date'){
       input=document.createElement('input');
       input.type=step.type;
       if(step.min!=null) input.min=step.min;


### PR DESCRIPTION
## Summary
- include `.input-wrap` styles for prefix/suffix units
- add `unitBox` helper in both wizards
- wrap pair fields and euro/percent fields using `unitBox`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863fabe884483339aa45322e50a722c