### PR TITLE
Update retirement age question text

### DIFF
--- a/pensionWizard.js
+++ b/pensionWizard.js
@@ -24,7 +24,7 @@ const steps = [
       { id: 'employerPct', label: '…or employer contribution (% of salary)', type: 'number', min: 0, max: 100, step: 0.1, optional: true }
     ]
   },
-  { id: 'retireAge', q: 'At what age do you plan to start drawing your pension?', type: 'number', min: 50, max: 75 },
+  { id: 'retireAge', q: 'At what age do you plan on retiring?', type: 'number', min: 50, max: 75 },
   { id: 'growth', q: 'Select an investment-growth (risk) profile for your pension.', type: 'riskCard' }
 ];
 

--- a/wizard.js
+++ b/wizard.js
@@ -5,7 +5,7 @@ const steps = [
   {id:"partnerExists", q:"Do you share your finances with a spouse or long-term partner (married, civil-partnered, or co-habiting)?", type:"boolean"},
   {id:"grossIncome", q:"What is your personal gross annual income (before tax), in euros?", type:"number", min:0},
   {id:"incomePercent", q:"Approximately what percentage of your current income would you like to receive each year after you retire?", type:"number", min:0, max:100, step:0.1},
-  {id:"retireAge", q:"At what age do you plan to start drawing your pension?", type:"number", min:18, max:100},
+  {id:"retireAge", q:"At what age do you plan on retiring?", type:"number", min:18, max:100},
   {id:"statePension", q:"Do you expect to qualify for the Irish State Pension?", type:"boolean"},
   {id:"partnerStatePension", q:"Will your partner qualify for the Irish State Pension?", type:"boolean", visIf:p=>p.partnerExists},
   {id:"partnerDob", q:"What is your partner’s date of birth?", type:"date", visIf:p=>p.partnerStatePension===true},


### PR DESCRIPTION
## Summary
- adjust retirement age question wording in the FY Money Calculator wizard
- apply same wording change to the Pension Projection wizard

## Testing
- `node --check wizard.js`
- `node --check pensionWizard.js`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6863f96a9a4083339cb565593020878c