### PR TITLE
Fix PDF summary spacing

### DIFF
--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -775,7 +775,7 @@ function generatePDF() {
   currY += headingH + gap;
   doc.setFontSize(12).setFont(undefined,'normal').setTextColor('#fff');
   doc.text(lines1, summaryX + padSide, currY, {lineHeightFactor:1.4});
-  const h1 = doc.getTextDimensions(lines1.join('\n')).h;
+  const h1 = lines1.length * summaryLineH;
   currY += h1 + 4; // 4-pt gap between paragraphs
   doc.text(lines2, summaryX + padSide, currY, {lineHeightFactor:1.4});
   summaryY += summaryBoxH;


### PR DESCRIPTION
## Summary
- ensure the summary paragraphs in the generated PDF are spaced correctly

## Testing
- `node --check pensionProjection.js`


------
https://chatgpt.com/codex/tasks/task_e_6865757abc1c8333a79120446770780a