### PR TITLE
Place warnings on dedicated page

### DIFF
--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -832,16 +832,28 @@ doc.addImage(
   summaryY += summaryBoxH;
 
   let rightY  = summaryY + 12;          // starts under both charts and summary
-  let pageNo  = 3;                    // we’re still on page 3
+  let pageNo  = 3;                      // we're still on page 3
 
-// Build a single array in display order (mandatory first if present)
-const allWarns = [];
-if (latestRun.mandatoryWarn) allWarns.push(latestRun.mandatoryWarn);
-allWarns.push(...latestRun.otherWarns);
+  // finish page 3 and start warnings on page 4
+  addFooter(pageNo++);
+  doc.addPage();
+  pageBG();
+  leftY = rightY = 60;
+  doc.setFontSize(18)
+     .setFont(undefined, 'bold')
+     .setTextColor(ACCENT_CYAN)
+     .text('Important Assumptions/Warnings', 50, leftY);
+  leftY += 22;
+  rightY = leftY;
 
-allWarns.forEach(w => placeBanner(doc, w));
+  // Build a single array in display order (mandatory first if present)
+  const allWarns = [];
+  if (latestRun.mandatoryWarn) allWarns.push(latestRun.mandatoryWarn);
+  allWarns.push(...latestRun.otherWarns);
 
-addFooter(pageNo);
+  allWarns.forEach(w => placeBanner(doc, w));
+
+  addFooter(pageNo);
 
 doc.save('planéir_report.pdf');
 const pdfUrl = doc.output('bloburl');

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -783,6 +783,19 @@ function generatePDF() {
   let rightY = summaryY + 12;
   leftY = rightY;
   let pageNo=3;
+
+  // finish page 3 and start warnings on page 4
+  addFooter(pageNo++);
+  doc.addPage();
+  pageBG();
+  leftY = rightY = 60;
+  doc.setFontSize(18)
+     .setFont(undefined,'bold')
+     .setTextColor(ACCENT_CYAN);
+  doc.text('Important Assumptions/Warnings',50,leftY);
+  leftY += 22;
+  rightY = leftY;
+
   const allWarns=[]; if(latestRun.mandatoryWarn) allWarns.push(latestRun.mandatoryWarn); allWarns.push(...latestRun.otherWarns);
   allWarns.forEach(w=>placeBanner(doc,w));
   addFooter(pageNo);


### PR DESCRIPTION
## Summary
- add a new page titled **Important Assumptions/Warnings**
- always move warning banners to this page for both PDF generators

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68659a446fc48333b47e931edc750540