### PR TITLE
Move warnings below PDF button

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -419,6 +419,8 @@ canvas {
           Despite this limitation, the calculator’s projections remain a reasonable reflection of expected retirement outcomes.<br><br>
           <em>For personalised analysis, please consult a qualified financial advisor.</em>
   </div>
+
+  <div id="calcWarnings"></div>
 </div>
 
       <div id="console" class="error"></div>

--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -86,6 +86,7 @@ try {
   // FIX: reset any previous SFT state
   document.getElementById('sftMessage').innerHTML = '';
   document.getElementById('sftModal').style.display = 'none';
+  setHTML('calcWarnings', '');
   let sftWarningHTML = '';
   const gross = +document.getElementById('grossIncome').value || 0;
   const pctNeed = (+document.getElementById('incomePercent').value || 0) / 100;
@@ -263,7 +264,9 @@ if (typeof v === 'boolean') val = fmtBool(v);
 return `<tr><td>${label}</td><td>${val}</td><td><span class="edit" onclick="wizard.open('${k}')">✏️</span></td></tr>`;
     }).join('');
   const tableHTML = `<table class="assumptions-table"><tbody>${rows}</tbody></table>`;
-  setHTML('results', resultHTML + earlyWarning + sftAssumpWarning + tableHTML);
+  const warningsHTML = earlyWarning + sftAssumpWarning;
+  setHTML('results', resultHTML + tableHTML);
+  setHTML('calcWarnings', warningsHTML);
 
 
   // ─── Build cash-flow & balance arrays ───────────────────────────────

--- a/pension-projection.html
+++ b/pension-projection.html
@@ -305,6 +305,7 @@ button.wizDot:focus-visible {
 
       <div id="postCalcContent" style="display:none;">
         <button id="downloadPdf" style="margin-top:1rem">Download PDF report</button>
+        <div id="calcWarnings"></div>
       </div>
 
       <div id="console" class="error"></div>

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -377,6 +377,7 @@ function drawContribChart(showMax) {
 document.getElementById('proj-form').addEventListener('submit', e => {
   e.preventDefault();
   try {
+    document.getElementById('calcWarnings').innerHTML = '';
     // Inputs
     const salaryRaw  = +document.getElementById('salary').value;
     salaryCapped    = Math.min(salaryRaw, MAX_SALARY_CAP);
@@ -501,6 +502,7 @@ if (retireAge < 50) {
     </div>`;
 }
 
+const warningsHTML = ageWarning + sftAssumpWarning;
 const resultsHTML = `
   <p>
     Max personal contribution allowed (age ${Math.floor(curAge)}):
@@ -514,7 +516,7 @@ const resultsHTML = `
     Projected value at age ${retireAge}:<br>
     <strong>€${projValue.toLocaleString()}</strong>
   </h2>
-` + ageWarning + sftAssumpWarning;
+`;
 
 let sftWarningHTML = '';
 if (projValue > sftLimit) {
@@ -608,6 +610,7 @@ if (projValue > sftLimit) {
       }).join('');
     const tableHTML = `<h3>Inputs</h3><table class="assumptions-table"><tbody>${rows}</tbody></table>`;
     document.getElementById('results').innerHTML = tableHTML + resultsHTML;
+    document.getElementById('calcWarnings').innerHTML = warningsHTML;
 
     latestRun.warningBlocks = [...document.querySelectorAll('#results .warning-block, #postCalcContent .warning-block')].map(el => {
       const strong = el.querySelector('strong');


### PR DESCRIPTION
## Summary
- add `calcWarnings` element to both calculators so all warning messages can be shown after the "Download PDF" button
- update JS logic to place warnings in this new section

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check fyMoneyCalculator.js`
- `node --check pensionProjection.js`

------
https://chatgpt.com/codex/tasks/task_e_686bb2a7bd84833398f221165b3325a4