### PR TITLE
Improve PDF input display

### DIFF
--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -559,6 +559,10 @@ return { inputs, outputs, assumptions: ASSUMPTIONS_TABLE_CONSTANT };
 
 const fmtBool = b => b ? 'Yes' : 'No';
 const fmtEuro = n => '€' + n.toLocaleString();
+const fmtPdfCell = v => {
+  if (typeof v === 'boolean') return v ? '✓' : '✗';
+  return v ? String(v) : 'N/A';
+};
 
 function generatePDF() {
 if (!latestRun) return;
@@ -720,7 +724,7 @@ doc.autoTable({
   margin: { left: 40, right: 40 + colW + columnGap },
   head: [['Input', 'Value']],
   body: Object.entries(latestRun.inputs)
-    .map(([k, v]) => [LABEL_MAP[k] ?? k, String(v || '—')]),
+    .map(([k, v]) => [LABEL_MAP[k] ?? k, fmtPdfCell(v)]),
   headStyles: { fillColor: ACCENT_CYAN, textColor: '#000' },
   bodyStyles: { fillColor: '#2a2a2a', textColor: '#fff' },
   alternateRowStyles: { fillColor: '#242424', textColor: '#fff' },

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -634,6 +634,10 @@ if (projValue > sftLimit) {
 document.getElementById('downloadPdf').addEventListener('click', generatePDF);
 
 function fmtEuro(n) { return '€' + n.toLocaleString(); }
+function fmtPdfCell(v) {
+  if (typeof v === 'boolean') return v ? '✓' : '✗';
+  return v ? String(v) : 'N/A';
+}
 
 function generatePDF() {
   if (!latestRun) return;
@@ -714,7 +718,7 @@ function generatePDF() {
   doc.text('Inputs & results',50,y3); y3+=22;
   const columnGap=20; const colW=(pageW-40*2-columnGap)/2;
   doc.autoTable({ startY:y3, margin:{left:40,right:40+colW+columnGap}, head:[['Input','Value']],
-    body:Object.entries(latestRun.inputs).map(([k,v])=>[LABEL_MAP[k]??k,String(v||'—')]),
+    body:Object.entries(latestRun.inputs).map(([k,v])=>[LABEL_MAP[k]??k,fmtPdfCell(v)]),
     headStyles:{ fillColor:ACCENT_CYAN, textColor:'#000' },
     bodyStyles:{ fillColor:'#2a2a2a', textColor:'#fff' },
     alternateRowStyles:{ fillColor:'#242424', textColor:'#fff' },


### PR DESCRIPTION
## Summary
- show ticks or crosses for boolean inputs in generated PDFs
- display `N/A` instead of a dash for missing numeric figures
- apply to both calculators (pension projection and FY money calculator)

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bb33728f8833389dc131105220b21