### PR TITLE
Fix missing PDF tick marks

### DIFF
--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -563,7 +563,8 @@ return { inputs, outputs, assumptions: ASSUMPTIONS_TABLE_CONSTANT };
 const fmtBool = b => b ? 'Yes' : 'No';
 const fmtEuro = n => '€' + n.toLocaleString();
 const fmtPdfCell = v => {
-  if (typeof v === 'boolean') return v ? '✓' : '✗';
+  if (typeof v === 'boolean')
+    return { content: String.fromCharCode(v ? 51 : 55), styles: { font: 'zapfdingbats' } };
   return v ? String(v) : 'N/A';
 };
 

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -638,7 +638,8 @@ document.getElementById('downloadPdf').addEventListener('click', generatePDF);
 
 function fmtEuro(n) { return '€' + n.toLocaleString(); }
 function fmtPdfCell(v) {
-  if (typeof v === 'boolean') return v ? '✓' : '✗';
+  if (typeof v === 'boolean')
+    return { content: String.fromCharCode(v ? 51 : 55), styles: { font: 'zapfdingbats' } };
   return v ? String(v) : 'N/A';
 }
 


### PR DESCRIPTION
## Summary
- render boolean values using Zapf Dingbats tick/cross glyphs
- apply same logic in the pension projection tool

## Testing
- `echo No tests`

------
https://chatgpt.com/codex/tasks/task_e_686bb63f501c8333bc4fbafacb39f3ba