### PR TITLE
Fix personal balance sheet wizard not loading

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -179,7 +179,7 @@ const wizardSteps = [
     ]
   }
 ];
-];
+
 
 let currentStep = 0;
 const totalSteps = wizardSteps.length;


### PR DESCRIPTION
## Summary
- remove extra closing bracket from `personalBalanceSheet.js`

## Testing
- `for f in *.js; do echo $f; node --check $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_686d0608ef648333a258bfb5e3f9f2fe