### PR TITLE
Fix dynamic display in personal balance sheet wizard

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -55,6 +55,7 @@
     .error { color:#ff4d4f; font-size:0.9rem; margin-top:4px; }
     .repeat-block{ position:relative; }
     .remove-link{ position:absolute; top:0; right:0; color:#ff4d4f; cursor:pointer; font-size:0.8rem; }
+    .tip{ display:inline-block; width:1.2rem; height:1.2rem; line-height:1.2rem; border-radius:50%; background:#00aaff; color:#fff; font-size:0.75rem; text-align:center; margin-left:0.25rem; cursor:help; }
   </style>
 </head>
 <body>

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -271,7 +271,10 @@ function renderStep(i){
   }
 
   btnNext.disabled=!validateStep();
-  container.querySelectorAll('input,select').forEach(el=>el.addEventListener('input',()=>{btnNext.disabled=!validateStep();}));
+  container.querySelectorAll('input,select').forEach(el=>{
+    el.addEventListener('input',()=>{btnNext.disabled=!validateStep();});
+    el.addEventListener('change',()=>{saveStepValues(); renderStep(currentStep);});
+  });
 }
 
 function clearErrors(){


### PR DESCRIPTION
## Summary
- style tooltip icon so it doesn't look like stray text
- rerender wizard step when a field value changes so conditional fields appear immediately

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d085bff10833387c1d14c6363f1f2