### PR TITLE
Improve mortgage wizard usability

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -56,6 +56,8 @@
     .repeat-block{ position:relative; }
     .remove-link{ position:absolute; top:0; right:0; color:#ff4d4f; cursor:pointer; font-size:0.8rem; }
     .tip{ display:inline-block; width:1.2rem; height:1.2rem; line-height:1.2rem; border-radius:50%; background:#00aaff; color:#fff; font-size:0.75rem; text-align:center; margin-left:0.25rem; cursor:help; }
+    .either-or{ display:flex; gap:1rem; }
+    .either-or .either-field{ flex:1; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- group related mortgage fields for either-or entry and add help text
- show grouped fields side-by-side with new styles

## Testing
- `node --check personalBalanceSheet.js`

------
https://chatgpt.com/codex/tasks/task_e_686d0b466d90833389eaf210302ce3f4