### PR TITLE
Clarify optional fields after renting a room

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -70,6 +70,7 @@
     .tip{ display:inline-block; width:1.2rem; height:1.2rem; line-height:1.2rem; border-radius:50%; background:#00aaff; color:#fff; font-size:0.75rem; text-align:center; margin-left:0.25rem; cursor:help; }
     .either-or{ display:flex; gap:1rem; }
     .either-or .either-field{ flex:1; }
+    .optional-info{ margin-top:1rem; font-weight:bold; color:#00aaff; }
   </style>
 </head>
 <body>

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -67,6 +67,7 @@ const wizardSteps = [
       {id:'homeValue', label:'Market value (€)', type:'number', showIf:d=>d.ownsHome==='Yes'},
       {id:'homeMortgage', label:'Outstanding mortgage (€)', type:'number', optional:true, showIf:d=>d.ownsHome==='Yes'},
       {id:'rentRoom', label:'Renting a room?', type:'select', options:['No','Yes occasional','Yes regular'], showIf:d=>d.ownsHome==='Yes'},
+      {id:'optionalNotice', type:'note', text:'The following details are optional.', showIf:d=>d.ownsHome==='Yes'},
       {id:'rentalIncome', label:'Annual rental income (€ gross)', type:'number', optional:true, showIf:d=>d.ownsHome==='Yes' && d.rentRoom && d.rentRoom!=='No'},
       {id:'repayment', label:'Annual mortgage repayment (€)', type:'number', optional:true, group:'repayRate', showIf:d=>d.ownsHome==='Yes', help:'Enter either this or the interest rate'},
       {id:'interestRate', label:'Interest rate (%)', type:'number', optional:true, group:'repayRate', showIf:d=>d.ownsHome==='Yes', help:'Enter either this or the annual repayment'},
@@ -259,6 +260,10 @@ function renderStep(i){
         const wrap=el('div');
         renderRepeat(wrap, field, arr);
         container.appendChild(wrap);
+      }else if(field.type==='note'){
+        if(field.showIf && !field.showIf(data)) return;
+        const note=el('p',{className:'optional-info',textContent:field.text});
+        container.appendChild(note);
       }else{
         if(field.showIf && !field.showIf(data)) return;
         const id=field.id;


### PR DESCRIPTION
## Summary
- highlight that remaining fields after the "Renting a room" question are optional
- style optional notice in the balance sheet wizard

## Testing
- `node --check personalBalanceSheet.js`


------
https://chatgpt.com/codex/tasks/task_e_686d14f1316883338ecea1312cb055be