### PR TITLE
Allow skipping cash inputs in step 4

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -94,8 +94,8 @@ const wizardSteps = [
     id:'cash', title:'How much cash do you keep in everyday accounts?', tooltip:'Instant access cash',
     store:'liquidity',
     fields:[
-      {id:'cash', label:'Cash on deposit (€)', type:'number'},
-      {id:'cashSavings', label:'Cash savings (€)', type:'number'}
+      {id:'cash', label:'Cash on deposit (€)', type:'number', optional:true},
+      {id:'cashSavings', label:'Cash savings (€)', type:'number', optional:true}
     ]
   },
   {


### PR DESCRIPTION
## Summary
- make the cash step inputs optional so the wizard can advance when blank

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d338a48288333b7a50ec10de9d455