### PR TITLE
Fix cash step optional

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -94,8 +94,8 @@ const wizardSteps = [
     id:'cash', title:'How much cash do you keep in everyday accounts?', tooltip:'Instant access cash',
     store:'liquidity',
     fields:[
-      {id:'cash', label:'Cash in current account (€)', type:'number'},
-      {id:'cashSavings', label:'Cash savings (€)', type:'number'}
+      {id:'cash', label:'Cash in current account (€)', type:'number', optional:true},
+      {id:'cashSavings', label:'Cash savings (€)', type:'number', optional:true}
     ]
   },
   {


### PR DESCRIPTION
## Summary
- allow skipping the cash step by making its fields optional

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d3457e7408333a98dcc375245d386