### PR TITLE
Display nicknamed assets on balance sheet

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -452,7 +452,7 @@ function renderBalanceSheet(data) {
   const lifestyleRows = [
     row('Primary home', pick(data,['lifestyle','primaryHome','homeValue'])),
     ... (data.lifestyle.holidayHomes||[])
-         .map((h,i)=>row(`Holiday home ${i+1}`, h.value))
+         .map(h=>row(`${h.nick} holiday home`, h.value))
   ].filter(Boolean);
 
   // -------------------------------- liquidity rows
@@ -467,12 +467,14 @@ function renderBalanceSheet(data) {
   // -------------------------------- longevity rows
   const longevityRows = [
     row('Pensions',    sumVals((data.longevity.pensions||[]).map(p=>+p.value||0))),
-    row('Diversified', sumVals((data.longevity.diversified||[]).map(d=>+d.value||0)))
+    ... (data.longevity.diversified||[])
+         .map(d=>row(`${d.nick} investments`, d.value))
   ].filter(Boolean);
 
   // -------------------------------- legacy rows
   const legacyRows = [
-    row('Inv. property', sumVals((data.legacy.investmentProps||[]).map(p=>+p.value||0))),
+    ... (data.legacy.investmentProps||[])
+         .map(p=>row(`${p.nick} inv. property`, p.value)),
     row('Private biz',   sumVals((data.legacy.privateBiz||[]).map(b=>+b.value||0))),
     row('Stocks',        sumVals((data.legacy.singleStocks||[]).map(s=>+s.value||0))),
     row('Collectibles',  sumVals((data.legacy.collectibles||[]).map(c=>+c.value||0)))


### PR DESCRIPTION
## Summary
- improve Personal Balance Sheet results to show nicknames
  - show each holiday home with its nickname
  - show each diversified account with nickname + "investments"
  - show each investment property with nickname + "inv. property"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c1bf24c608333be0665d8daf976da