### PR TITLE
Fix liability totals include mortgages

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -416,7 +416,13 @@ function computeTotals(data) {
   const collect    = sumVals((data.legacy.collectibles || []).map(c => +c.value || 0));
   const legacy     = invProps + privBiz + stocks + collect;
 
-  const liabs      = sumVals((data.liabilities || []).map(l => +l.amount || 0));
+  const mortgages  =
+    (+pick(data, ['lifestyle', 'primaryHome', 'homeMortgage']) || 0) +
+    sumVals((data.lifestyle.holidayHomes || []).map(h => +h.mortgage || 0)) +
+    sumVals((data.legacy.investmentProps || []).map(p => +p.mortgage || 0));
+
+  const liabs      = mortgages +
+    sumVals((data.liabilities || []).map(l => +l.amount || 0));
 
   return { lifestyle, liquidity, longevity, legacy, liabs };
 }


### PR DESCRIPTION
## Summary
- include mortgages when computing liabilities in personal balance sheet

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c1d2abe748333a797d8db303ce7cf