### PR TITLE
Add net asset donut chart

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -47,6 +47,10 @@
     .bs-card ul{list-style:none;padding:0;margin:.4rem 0 0 0;font-size:.9rem;line-height:1.4;flex:1}
     .bs-card li{display:flex;justify-content:space-between;border-bottom:1px solid #ddd;padding:.25rem 0}
     .bs-card .subtotal{font-weight:700;margin-top:auto}
+
+    /* Donut chart wrapper */
+    .chart-wrapper{position:relative;width:100%;max-width:420px;height:280px;margin:2rem auto}
+    @media(max-width:480px){.chart-wrapper{height:200px}}
     :root{
       --accent-1:#00aaff;
       --accent-2:#00ff88;
@@ -90,8 +94,12 @@
       </div>
     </div>
     <div class="bs-grid"></div>
+    <div class="chart-wrapper">
+      <canvas id="assetsChart" tabindex="0" aria-label="Breakdown of net assets" role="img"></canvas>
+    </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="./personalBalanceSheet.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style chart wrapper for personal balance sheet
- embed Chart.js and canvas markup for new donut chart
- compute donut data and render responsive chart with labels and center text

## Testing
- `npx eslint personalBalanceSheet.js` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c21dd2c7c8333b4983bd258bfe373