### PR TITLE
Add balance sheet results heading & edit button

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -86,6 +86,7 @@
 
   <!-- ========== NEW BALANCE-SHEET RESULT PANEL ========== -->
   <div id="balanceSheet" class="balance-sheet hidden">
+    <h2>Results</h2>
     <div class="bs-header">
       <div class="net-worth"><span id="netAssets">Net assets €0</span></div>
       <div class="gross-wrap">
@@ -93,6 +94,7 @@
         <div>Total liabilities <span id="totLiabs">€0</span></div>
       </div>
     </div>
+    <button id="editDetails">Edit details</button>
     <div class="bs-grid"></div>
     <div class="chart-wrapper">
       <canvas id="assetsChart" tabindex="0" aria-label="Breakdown of net assets" role="img"></canvas>

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -591,4 +591,11 @@ function onSubmit(){
   saveStepValues();      // capture final page values
   renderBalanceSheet(personalBalanceSheet);
 }
+
+// Allow editing details from the results view
+document.getElementById('editDetails').addEventListener('click', () => {
+  document.getElementById('balanceSheet').classList.add('hidden');
+  modal.classList.remove('hidden');
+  renderStep(0);
+});
 // end of Personal Balance Sheet script


### PR DESCRIPTION
## Summary
- show a *Results* heading on the balance sheet output
- allow users to reopen the wizard by adding an **Edit details** button

## Testing
- `node --check personalBalanceSheet.js`

------
https://chatgpt.com/codex/tasks/task_e_68800d27ab38833399671e4d1202c20e