### PR TITLE
Fix optional notice display

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -225,6 +225,11 @@ function renderRepeat(container, field, values){
     const groups={};
     field.fields.forEach(f=>{
       if(f.showIf && !f.showIf(val)) return;
+      if(f.type==='note'){
+        const note=el('p',{className:'optional-info',textContent:f.text});
+        block.appendChild(note);
+        return;
+      }
       const inputId=`${field.id}-${idx}-${f.id}`;
       const labelTxt=typeof f.label==='function'?f.label(val):f.label;
       let parent=block;


### PR DESCRIPTION
## Summary
- ensure `note` fields in repeat blocks render as text instead of inputs

## Testing
- `node --check personalBalanceSheet.js`

------
https://chatgpt.com/codex/tasks/task_e_68800f42f6048333b44b8dabeea204a1