### PR TITLE
Improve balance sheet display

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -48,6 +48,8 @@
     .bs-card li{display:flex;justify-content:space-between;border-bottom:1px solid #ddd;padding:.25rem 0}
     .bs-card .subtotal{font-weight:700;margin-top:auto}
 
+    #editDetails{align-self:start;margin-top:1rem}
+
     /* Donut chart wrapper */
     .chart-wrapper{position:relative;width:100%;max-width:420px;height:280px;margin:2rem auto}
     @media(max-width:480px){.chart-wrapper{height:200px}}
@@ -94,8 +96,8 @@
         <div>Total liabilities <span id="totLiabs">€0</span></div>
       </div>
     </div>
-    <button id="editDetails">Edit details</button>
     <div class="bs-grid"></div>
+    <button id="editDetails">Edit details</button>
     <div class="chart-wrapper">
       <canvas id="assetsChart" tabindex="0" aria-label="Breakdown of net assets" role="img"></canvas>
     </div>

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -569,7 +569,8 @@ function renderBalanceSheet(data) {
   const legacyRows = [
     ... (data.legacy.investmentProps||[])
          .map(p=>row(`${p.nick} inv. property`, p.value)),
-    row('Private biz',   sumVals((data.legacy.privateBiz||[]).map(b=>+b.value||0))),
+    ... (data.legacy.privateBiz||[])
+         .map(b=>row(b.name || 'Private biz', b.value)),
     row('Stocks',        sumVals((data.legacy.singleStocks||[]).map(s=>+s.value||0))),
     row('Collectibles',  sumVals((data.legacy.collectibles||[]).map(c=>+c.value||0)))
   ].filter(Boolean);


### PR DESCRIPTION
## Summary
- show each business name in personal balance sheet results
- move Edit Details button under the asset list and style it

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6880115511ec83338a8dafab73794c7e