### PR TITLE
Fix donut chart label and tooltip z-order

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -99,7 +99,7 @@
     <div class="bs-grid"></div>
     <button id="editDetails">Edit details</button>
     <div class="chart-wrapper">
-      <canvas id="assetsChart" tabindex="0" aria-label="Breakdown of net assets" role="img"></canvas>
+      <canvas id="assetsChart" tabindex="0" aria-label="Breakdown of gross assets" role="img"></canvas>
     </div>
   </div>
 

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -465,15 +465,16 @@ function renderAssetsChart(t){
 
   const centerText = {
     id:'centerText',
-    afterDraw(chart){
+    afterDatasetsDraw(chart){
       const {ctx, chartArea:{width,height}} = chart;
       ctx.save();
       ctx.font = '600 1.2rem Inter';
       ctx.textAlign='center';
       ctx.fillStyle='#fff';
-      ctx.fillText('Net Assets', width/2, height/2 - 6);
+      ctx.fillText('Gross Assets', width/2, height/2 - 6);
       ctx.font='700 1.4rem Inter';
       ctx.fillText(`€${total.toLocaleString()}`, width/2, height/2 + 18);
+      ctx.restore();
     }
   };
 


### PR DESCRIPTION
## Summary
- draw center text before tooltips so hover popup isn't hidden
- label donut chart as *Gross Assets* and update aria label

## Testing
- `node --check personalBalanceSheet.js`

------
https://chatgpt.com/codex/tasks/task_e_688013c3d608833393e52d6e9b490f6c