### PR TITLE
Fix results heading clipped on balance sheet

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -10,7 +10,18 @@
   <style>
     /* ========== EXISTING WIZARD STYLES (unchanged) ========== */
     *{box-sizing:border-box}
-    body{margin:0;font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;height:100vh}
+    body{
+      margin:0;
+      font-family:'Inter',sans-serif;
+      background:#1a1a1a;
+      color:#fff;
+      display:flex;
+      flex-direction:column;
+      justify-content:flex-start;
+      align-items:center;
+      min-height:100vh;
+      padding:calc(env(safe-area-inset-top,0) + 2rem) 1rem calc(env(safe-area-inset-bottom,0) + 2rem);
+    }
     button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0}
     .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:flex;justify-content:center;align-items:flex-start;overflow-y:auto;padding:1rem 0;z-index:9999}
     .modal.hidden{display:none}


### PR DESCRIPTION
## Summary
- add safe area padding to `personal-balance-sheet.html` body to prevent heading from being clipped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880173050908333a879facb3c6c0134