### PR TITLE
Improve mobile layout of balance sheet results

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -22,7 +22,7 @@
       min-height:100vh;
       padding:calc(env(safe-area-inset-top,0) + 2rem) 1rem calc(env(safe-area-inset-bottom,0) + 2rem);
     }
-    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0}
+    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0;min-height:2.75rem}
     .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:flex;justify-content:center;align-items:flex-start;overflow-y:auto;padding:1rem 0;z-index:9999}
     .modal.hidden{display:none}
     .wizard-card{display:flex;flex-direction:column;width:90%;max-width:420px;background:#2a2a2a;border-radius:16px;padding:2rem;margin:auto 0}
@@ -59,6 +59,13 @@
     .bs-header{display:flex;justify-content:space-between;align-items:center;background:#f4f4f4;border-radius:12px;padding:1rem 1.2rem;margin-bottom:1.2rem}
     .bs-header .net-worth{font-weight:700;font-size:1.4rem}
     .bs-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.2rem}
+    @media(max-width:600px){
+      .bs-grid{grid-template-columns:repeat(auto-fit,minmax(200px,1fr))}
+    }
+    @media(max-width:480px){
+      .bs-header{flex-direction:column;align-items:flex-start;gap:.5rem}
+      .bs-header .net-worth{font-size:1.2rem}
+    }
     .bs-card{background:#f4f4f4;border-radius:12px;padding:1rem 1.2rem;display:flex;flex-direction:column}
     .bs-card h3{margin:0 0 .4rem 0;font-size:1rem;font-weight:700;color:#fff;padding:.3rem .5rem;border-radius:4px}
     .bs-card ul{list-style:none;padding:0;margin:.4rem 0 0 0;font-size:.9rem;line-height:1.4;flex:1}
@@ -69,6 +76,7 @@
 
     /* Donut chart wrapper */
     .chart-wrapper{position:relative;width:100%;max-width:420px;height:280px;margin:2rem auto}
+    .chart-wrapper canvas{display:block;max-width:100%;height:auto}
     @media(max-width:480px){.chart-wrapper{height:200px}}
     :root{
       --accent-1:#00aaff;


### PR DESCRIPTION
## Summary
- ensure button touch targets are at least 44px tall
- add responsive header and grid layouts for small screens
- make chart canvas responsive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881353a295c8333905c9da6c79ad6c5