### PR TITLE
Remove popup step tooltips

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -42,7 +42,6 @@
     .error{color:#ff4d4f;font-size:.9rem;margin-top:4px}
     .repeat-block{position:relative}
     .remove-link{position:absolute;top:0;right:0;color:#ff4d4f;cursor:pointer;font-size:.8rem}
-    .tip{display:inline-block;width:1.2rem;height:1.2rem;line-height:1.2rem;border-radius:50%;background:#00aaff;color:#fff;font-size:.75rem;text-align:center;margin-left:.25rem;cursor:help}
     .either-or{display:flex;gap:1rem}
     .either-or .either-field{flex:1}
     .optional-info{margin-top:1rem;font-weight:bold;color:#00aaff}

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -260,7 +260,8 @@ function renderStep(i){
   const step=wizardSteps[i];
   prog.textContent=`Step ${i+1} of ${totalSteps}`;
   progFill.style.width=((i+1)/totalSteps*100)+"%";
-  titleEl.innerHTML=`${step.title} <span title="${step.tooltip}" class="tip">?</span>`;
+  // Display the step title only; remove tooltip "?" icon
+  titleEl.textContent = step.title;
   dots.innerHTML=wizardSteps.map((_,idx)=>`<button class="wizDot${idx===i?' active':''}" data-idx="${idx}"></button>`).join('');
   dots.querySelectorAll('button').forEach(b=>b.onclick=()=>{saveStepValues();renderStep(+b.dataset.idx);});
   container.innerHTML='';


### PR DESCRIPTION
## Summary
- remove `.tip` style and the question mark icons on Personal Balance Sheet wizard steps

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688135c518cc8333a0c89ec522c73273