### PR TITLE
Improve canvas context for pdf export

### DIFF
--- a/canvas-readfreq-patch.js
+++ b/canvas-readfreq-patch.js
@@ -1,0 +1,19 @@
+// Patch canvas.getContext to use willReadFrequently for 2D contexts
+const origGetContext = HTMLCanvasElement.prototype.getContext;
+
+if (!origGetContext.__willReadFreqPatch) {
+  HTMLCanvasElement.prototype.getContext = function(type, options) {
+    if (type === '2d') {
+      try {
+        const opts = Object.assign({}, options, { willReadFrequently: true });
+        return origGetContext.call(this, type, opts);
+      } catch (e) {
+        return origGetContext.call(this, type, options);
+      }
+    }
+    return origGetContext.call(this, type, options);
+  };
+  HTMLCanvasElement.prototype.getContext.__willReadFreqPatch = true;
+}
+
+export {};

--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -131,7 +131,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.0/dist/jspdf.plugin.autotable.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js"></script>
+  <script type="module" src="canvas-readfreq-patch.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js"></script>
   <script type="module" src="pdfWarningHelpers.js"></script>
   <script type="module" src="./personalBalanceSheet.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- patch `HTMLCanvasElement.getContext` to enable `willReadFrequently` for 2D canvas
- load the patch before the html2canvas/html2pdf bundle in Personal Balance Sheet page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68838d30b16483338f9c262c29a5a933