### PR TITLE
Fix jsPDF reference

### DIFF
--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -1,6 +1,9 @@
 // Wizard logic for Personal Balance Sheet
 import html2canvas from "./html2canvas.esm.js";
 import { jsPDF } from "./jspdf.es.min.js";
+// expose jsPDF under the classic `jspdf` namespace for backward compatibility
+// with any code that might still expect the UMD bundle's global
+window.jspdf = { jsPDF };
 
 const origGetCtx = HTMLCanvasElement.prototype.getContext;
 if(!origGetCtx.__willReadFreqPatch){


### PR DESCRIPTION
## Summary
- ensure the jsPDF ESM import is exposed under the classic `jspdf` namespace so `generatePDF()` always finds it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883992356208333b60d2883b74667d4