### PR TITLE
Fix Chart.js ESM error

### DIFF
--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -450,7 +450,7 @@ canvas {
       <!-- End SFT modal -->
 
       <!-- PASTE the JavaScript below this line -->
-      <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
       <!-- ✅ 1. jsPDF core (UMD build attaches itself to window.jspdf) -->
       <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
       <!-- ✅ 2. AutoTable plugin (must come right after jsPDF) -->

--- a/pension-projection.html
+++ b/pension-projection.html
@@ -6,7 +6,7 @@
   <title>Pension Growth Projection</title>
  <link rel="icon" type="image/png" href="favicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
 
   <style>
     *{box-sizing:border-box}

--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -145,7 +145,7 @@
     <button id="downloadPdf" style="margin-top:1rem">Download PDF report</button>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
   <script src="./jspdf.umd.min.js"></script>
   <script type="module" src="pdfWarningHelpers.js"></script>
   <script type="module" src="./personalBalanceSheet.js"></script>


### PR DESCRIPTION
## Summary
- load Chart.js UMD build instead of the ESM build in HTML pages

## Testing
- `node -e "const fs=require('fs');console.log(/chart\.umd\.js/.test(fs.readFileSync('personal-balance-sheet.html','utf8')));"`

------
https://chatgpt.com/codex/tasks/task_e_68839e3975388333b046fdf6b192c14c