### PR TITLE
Reduce header fonts in balance sheet PDF

### DIFF
--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -74,14 +74,14 @@
       font-weight:700
     }
     .bs-header{display:flex;justify-content:space-between;align-items:center;background:#f4f4f4;border-radius:12px;padding:1rem 1.2rem;margin-bottom:1.2rem}
-    .bs-header .net-worth{font-weight:700;font-size:1.4rem}
+    .bs-header .net-worth{font-weight:700;font-size:1.2rem}
     .bs-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.2rem}
     @media(max-width:600px){
       .bs-grid{grid-template-columns:repeat(auto-fit,minmax(200px,1fr))}
     }
     @media(max-width:480px){
       .bs-header{flex-direction:column;align-items:flex-start;gap:.5rem}
-      .bs-header .net-worth{font-size:1.2rem}
+      .bs-header .net-worth{font-size:1rem}
     }
     .bs-card{background:#f4f4f4;border-radius:12px;padding:1rem 1.2rem;display:flex;flex-direction:column}
     .bs-card h3{margin:0 0 .4rem 0;font-size:1rem;font-weight:700;color:#fff;padding:.3rem .5rem;border-radius:4px}
@@ -105,7 +105,7 @@
     .card-liquidity h3{background:var(--accent-2)}
     .card-longevity h3{background:var(--accent-3)}
     .card-legacy h3{background:var(--accent-4)}
-    .gross-wrap{display:flex;flex-direction:column;text-align:right}
+    .gross-wrap{display:flex;flex-direction:column;text-align:right;font-size:.9rem}
     .gross-wrap div{margin:0}
   </style>
 </head>

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -726,8 +726,8 @@ Understanding and reviewing this breakdown regularly is essential—it helps ens
   const leftX = headerX + colW / 2;
   const rightX = headerX + colW + colW / 2;
 
-  const labelSize = 12;   // match table headers
-  const valueSize = 10;   // match table body
+  const labelSize = 10;   // slightly smaller fonts for summary box
+  const valueSize = 8;    // slightly smaller fonts for summary box
   const spacing    = 4;
 
   // ---- Net Assets (single column)


### PR DESCRIPTION
## Summary
- shrink font sizes for the gross assets summary in the generated PDF
- reduce corresponding styles in the HTML view

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6883ce0aa4748333a58ab013c644c005