### PR TITLE
Add Full Monty wizard skeleton

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -1,0 +1,179 @@
+import { animate, addKeyboardNav } from './wizardCore.js';
+
+const storageKey = 'fullMontyDraft';
+let data = JSON.parse(localStorage.getItem(storageKey) || '{}');
+function persist() {
+  localStorage.setItem(storageKey, JSON.stringify(data));
+}
+
+export const wizardSteps = [
+  { title: 'Profile', inputs: [
+      { id: 'dob', label: 'Your date of birth', type: 'date', required: true },
+      { id: 'partner', label: 'Do you have a partner?', type: 'boolean' },
+      { id: 'partnerDob', label: 'Partner date of birth', type: 'date', showIf: 'partner' }
+  ]},
+  { title: 'Income & Work', inputs: [
+      { id: 'salary', label: 'Gross annual salary (€)', type: 'currency', required: true },
+      { id: 'rentInc', label: 'Annual rental income (€)', type: 'currency' },
+      { id: 'employed', label: 'Are you an employee?', type: 'boolean', default: true }
+  ]},
+  { title: 'Pension Contributions', inputs: [
+      { id: 'potNow', label: 'Current pension value (€)', type: 'currency' },
+      { id: 'youPct', label: 'Your contribution (% of salary)', type: 'percent' },
+      { id: 'youFixed', label: '\u2026or fixed annual amount (€)', type: 'currency' },
+      { id: 'employerPct', label: 'Employer contribution (% of salary)', type: 'percent' },
+      { id: 'employerFixed', label: '\u2026or fixed annual amount (€)', type: 'currency' }
+  ]},
+  { title: 'Retirement Preferences', inputs: [
+      { id: 'retAge', label: 'Desired retirement age', type: 'number', min: 50, max: 70, default: 65 },
+      { id: 'incomeNeed', label: '% of salary you\u2019ll need in retirement', type: 'percent', default: 70 },
+      { id: 'statePenMe', label: 'Will you collect the State Pension?', type: 'boolean', default: true },
+      { id: 'statePenPr', label: 'Partner entitled to State Pension?', type: 'boolean', showIf: 'partner' }
+  ]},
+  { title: 'Other Pensions', inputs: [
+      { id: 'hasDB', label: 'Will you receive a Defined-Benefit pension?', type: 'boolean' },
+      { id: 'dbAnnual', label: 'DB annual amount at retirement (€)', type: 'currency', showIf: 'hasDB' },
+      { id: 'dbStart', label: 'DB pension starts at age', type: 'number', min: 50, max: 100, showIf: 'hasDB' }
+  ]},
+  { title: 'Risk & Growth', inputs: [
+      { id: 'growth', label: 'Choose a growth profile', type: 'select',
+        options: [
+          { value: 0.04, text: 'Low \u00b7 \u22484 % p.a.' },
+          { value: 0.05, text: 'Balanced \u00b7 \u22485 % p.a.' },
+          { value: 0.06, text: 'High \u00b7 \u22486 % p.a.' },
+          { value: 0.07, text: 'Very-high \u00b7 \u22487 % p.a.' }
+        ],
+        default: 0.05 }
+  ]},
+  { title: 'Assets & Liabilities', component: 'balanceSheetWizard' }
+];
+
+const modal = document.getElementById('fullMontyModal');
+const container = document.getElementById('fmStepContainer');
+const btnBack = document.getElementById('fmBack');
+const btnNext = document.getElementById('fmNext');
+const dots    = document.getElementById('fmDots');
+const progEl  = document.getElementById('fmProgress');
+const progFill= document.getElementById('fmProgressFill');
+let cur = 0;
+
+function visibleInputs(step) {
+  if (!step.inputs) return [];
+  return step.inputs.filter(inp => !inp.showIf || data[inp.showIf]);
+}
+
+function createInput(inp) {
+  const wrap = document.createElement('div');
+  wrap.className = 'wiz-field';
+  if (inp.label) {
+    const label = document.createElement('label');
+    label.textContent = inp.label;
+    label.htmlFor = inp.id;
+    wrap.appendChild(label);
+  }
+  let el;
+  if (inp.type === 'boolean') {
+    el = document.createElement('select');
+    el.id = inp.id;
+    el.innerHTML = '<option value="">--</option><option value="true">Yes</option><option value="false">No</option>';
+    if (data[inp.id] !== undefined) el.value = String(data[inp.id]);
+  } else if (inp.type === 'select') {
+    el = document.createElement('select');
+    el.id = inp.id;
+    inp.options.forEach(o => {
+      const opt = document.createElement('option');
+      opt.value = o.value;
+      opt.textContent = o.text;
+      el.appendChild(opt);
+    });
+    el.value = data[inp.id] ?? inp.default ?? inp.options[0].value;
+  } else {
+    el = document.createElement('input');
+    el.id = inp.id;
+    el.type = 'number';
+    if (inp.type === 'date') el.type = 'date';
+    if (inp.min != null) el.min = inp.min;
+    if (inp.max != null) el.max = inp.max;
+    if (data[inp.id] != null) el.value = data[inp.id];
+    else if (inp.default != null) el.value = inp.default;
+  }
+  el.addEventListener('input', () => {
+    let val = el.value;
+    if (inp.type === 'boolean') val = val === '' ? null : val === 'true';
+    else if (inp.type === 'number' || inp.type === 'currency' || inp.type === 'percent') val = val === '' ? '' : +val;
+    data[inp.id] = val;
+    persist();
+    updateNext();
+  });
+  wrap.appendChild(el);
+  return wrap;
+}
+
+function updateNext() {
+  const step = wizardSteps[cur];
+  let valid = true;
+  for (const inp of visibleInputs(step)) {
+    const val = data[inp.id];
+    if (inp.required && (val === '' || val === null || val === undefined)) valid = false;
+    if (inp.min != null && typeof val === 'number' && val < inp.min) valid = false;
+    if (inp.max != null && typeof val === 'number' && val > inp.max) valid = false;
+  }
+  if (cur === wizardSteps.length - 1) {
+    btnNext.textContent = 'Continue to Results';
+    btnNext.disabled = true;
+  } else {
+    btnNext.textContent = 'Next';
+    btnNext.disabled = !valid;
+  }
+}
+
+function render() {
+  const step = wizardSteps[cur];
+  progEl.textContent = `Step ${cur + 1} of ${wizardSteps.length}`;
+  progFill.style.width = ((cur + 1) / wizardSteps.length * 100) + '%';
+  container.innerHTML = '';
+  const h = document.createElement('h3');
+  h.textContent = step.title;
+  container.appendChild(h);
+  if (step.component) {
+    const p = document.createElement('p');
+    p.textContent = 'TODO: Integrate balance sheet wizard.';
+    container.appendChild(p);
+  } else {
+    visibleInputs(step).forEach(inp => container.appendChild(createInput(inp)));
+  }
+  dots.innerHTML = wizardSteps.map((_, i) => `<button class="wizDot${i===cur?' active':''}" data-idx="${i}"></button>`).join('');
+  dots.querySelectorAll('button').forEach(b => b.addEventListener('click', () => { cur = +b.dataset.idx; render(); }));
+  btnBack.style.display = cur === 0 ? 'none' : '';
+  updateNext();
+  const focusable = container.querySelector('input,select');
+  if (focusable) focusable.focus();
+}
+
+function next() {
+  if (btnNext.disabled) return;
+  animate(container,'next');
+  cur++;
+  if (cur >= wizardSteps.length) {
+    modal.classList.add('hidden');
+    return;
+  }
+  render();
+}
+
+function back() {
+  if (cur === 0) return;
+  animate(container,'back');
+  cur--; render();
+}
+
+btnNext.addEventListener('click', next);
+btnBack.addEventListener('click', back);
+addKeyboardNav(modal,{back,next,close:()=>modal.classList.add('hidden'),getCur:()=>cur,getTotal:()=>wizardSteps.length});
+
+export function openFullMontyWizard() {
+  cur = 0;
+  modal.classList.remove('hidden');
+  render();
+}
+

--- a/index-enhancements.js
+++ b/index-enhancements.js
@@ -1,0 +1,11 @@
+import { openFullMontyWizard } from './fullMontyWizard.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('launchFullMonty');
+  if (btn) {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      openFullMontyWizard();
+    });
+  }
+});

--- a/index.html
+++ b/index.html
@@ -176,6 +176,80 @@
       }
     }
 
+    /* === Full Monty button === */
+    .btn-full-monty {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      padding: 1rem 1.8rem;
+      font-weight: 700;
+      font-size: 1.05rem;
+      color: #fff;
+      text-decoration: none;
+      cursor: pointer;
+      background: linear-gradient(135deg, #c000ff 0%, #7f00ff 100%);
+      box-shadow: 0 0 18px rgba(192, 0, 255, .6);
+      transition: transform .25s, box-shadow .25s, filter .25s;
+    }
+    .btn-full-monty:hover,
+    .btn-full-monty:focus-visible {
+      transform: scale(1.03);
+      box-shadow: 0 0 28px rgba(192, 0, 255, .9);
+      filter: brightness(1.15);
+    }
+
+    /* Wizard basics */
+    button {
+      padding: .8rem 1.2rem;
+      font-weight: 700;
+      font-size: 1rem;
+      border: none;
+      border-radius: 50px;
+      cursor: pointer;
+      color: #1a1a1a;
+      background: linear-gradient(135deg, #00ff88, #0099ff);
+      margin: .3rem 0;
+      min-height: 2.75rem;
+    }
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+    .modal.hidden { display: none; }
+    .wizard-card {
+      display: flex;
+      flex-direction: column;
+      max-width: 420px;
+      border-radius: 16px;
+      padding: 2rem;
+      background: #2a2a2a;
+    }
+    #fullMontyModal h3 { font-weight: 600; font-size: 1.1rem; color: #fff; }
+    .wiz-header { text-align: center; margin-bottom: 1.2rem; }
+    #fmProgress { margin: 0 0 .8rem 0; }
+    #fmProgressBar { height: 6px; background:#ddd; border-radius:3px; margin:0 24px 12px; }
+    #fmProgressFill { height:100%; width:0; background:#c000ff; border-radius:3px; transition:width .25s ease; }
+    #fmDots { display:flex; justify-content:center; gap:8px; }
+    button.wizDot {
+      width:14px; height:14px; padding:0; line-height:0;
+      border:none; border-radius:50%; background:#888; cursor:pointer;
+    }
+    button.wizDot.active,
+    button.wizDot:focus-visible { background:#c000ff; }
+    .wizard-controls { display:flex; justify-content:space-between; margin-top:auto; }
+    @keyframes slideInLeft{from{transform:translateX(-40px);opacity:0}to{transform:none;opacity:1}}
+    @keyframes slideInRight{from{transform:translateX(40px);opacity:0}to{transform:none;opacity:1}}
+    #fmStepContainer.anim-left{animation:slideInLeft .25s ease-out both}
+    #fmStepContainer.anim-right{animation:slideInRight .25s ease-out both}
+
   </style>
 </head>
 <body>
@@ -198,6 +272,9 @@
   </div>
 
   <div class="container">
+    <a id="launchFullMonty" class="btn-full-monty" aria-label="Launch Full Monty wizard">
+      Full Monty&nbsp;(all-in-one)
+    </a>
     <!-- Bubble #1 -->
     <div class="bubble" onclick="location.href='fy-money-calculator.html'">
       <div class="bubble-icon">💸</div>
@@ -216,5 +293,24 @@
       <span>Personal Balance<br />Sheet</span>
     </div>
   </div>
+
+  <!-- Full Monty wizard overlay -->
+  <div id="fullMontyModal" class="modal hidden">
+    <div class="wizard-card">
+      <div class="wiz-header">
+        <h3 id="fmProgress"></h3>
+        <div id="fmProgressBar"><div id="fmProgressFill"></div></div>
+        <div id="fmDots"></div>
+      </div>
+      <div id="fmStepContainer"></div>
+      <div class="wizard-controls">
+        <button id="fmBack">Back</button>
+        <button id="fmNext">Next</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="./index-enhancements.js"></script>
+  <script type="module" src="./fullMontyWizard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add neon Full Monty button on the home page
- include wizard modal markup and styling
- create index-enhancements.js to wire up the launch button
- implement fullMontyWizard.js for input flow and localStorage persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883d9c7a68483339754deee79d2ad45