### PR TITLE
Align Full Monty wizard UI with Pension style

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -8,20 +8,44 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&display=swap" rel="stylesheet">
   <style>
-    body {font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh;padding:1rem;}
-    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0;min-height:2.75rem;}
+    :root{
+      --accent:#c000ff;
+      --glow:#00ff88;
+      --danger:#ff5c5c;
+    }
+    *{box-sizing:border-box}
+    body{font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh;padding:1rem;margin:0;}
+    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0;min-height:2.75rem;transition:transform .25s,box-shadow .25s;}
+    button:hover{transform:scale(1.03);box-shadow:0 0 22px rgba(0,255,136,.8);}
     .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;}
     .modal.hidden{display:none;}
-    .wizard-card{display:flex;flex-direction:column;max-width:420px;border-radius:16px;padding:2rem;background:#2a2a2a;}
+    .wizard-card{display:flex;flex-direction:column;max-width:640px;border-radius:16px;padding:2rem;background:#2a2a2a;}
     #fullMontyModal h3{font-weight:600;font-size:1.1rem;color:#fff;}
     .wiz-header{text-align:center;margin-bottom:1.2rem;}
     #fmProgress{margin:0 0 .8rem 0;}
     #fmProgressBar{height:6px;background:#ddd;border-radius:3px;margin:0 24px 12px;}
-    #fmProgressFill{height:100%;width:0;background:#c000ff;border-radius:3px;transition:width .25s ease;}
+    #fmProgressFill{height:100%;width:0;background:var(--accent);border-radius:3px;transition:width .25s ease;}
     #fmDots{display:flex;justify-content:center;gap:8px;}
-    button.wizDot{width:14px;height:14px;padding:0;line-height:0;border:none;border-radius:50%;background:#888;cursor:pointer;}
-    button.wizDot.active,button.wizDot:focus-visible{background:#c000ff;}
+    button.wizDot{width:14px;height:14px;padding:0;line-height:0;border:none;border-radius:50%;background:#888;background-image:none!important;cursor:pointer;}
+    button.wizDot.active,button.wizDot:focus-visible{background:var(--accent);}
     .wizard-controls{display:flex;justify-content:space-between;margin-top:auto;}
+    .form{display:flex;flex-direction:column;gap:1rem;}
+    .form-group{margin-bottom:1rem;}
+    .form-2col{display:grid;grid-template-columns:1fr 1fr;gap:1rem;}
+    @media(max-width:480px){.form-2col{grid-template-columns:1fr;}}
+    .form-group.control{display:flex;align-items:center;gap:.5rem;margin-bottom:1rem;}
+    label{display:block;margin-bottom:.4rem;font-weight:600;}
+    .form-group.control label{margin:0;font-weight:400;}
+    input[type=date],input[type=number],input[type=text],select{width:100%;padding:.55rem .7rem;border:1px solid transparent;border-radius:8px;background:#404040;color:#fff;}
+    input::placeholder{color:#aaa;}
+    input:focus,select:focus{outline:none;border-color:var(--glow);box-shadow:0 0 0 3px rgba(0,255,136,.25);}
+    .input-wrap{position:relative;display:block;}
+    .input-wrap.prefix input{padding-left:1.6rem;}
+    .input-wrap.suffix input{padding-right:1.6rem;}
+    .input-wrap .unit{position:absolute;top:50%;transform:translateY(-50%);color:#bbb;font-size:.9em;pointer-events:none;}
+    .input-wrap.prefix .unit{left:.5rem;}
+    .input-wrap.suffix .unit{right:.5rem;}
+    .error{color:var(--danger);margin-top:.5rem;}
     @keyframes slideInLeft{from{transform:translateX(-40px);opacity:0}to{transform:none;opacity:1}}
     @keyframes slideInRight{from{transform:translateX(40px);opacity:0}to{transform:none;opacity:1}}
     #fmStepContainer.anim-left{animation:slideInLeft .25s ease-out both}


### PR DESCRIPTION
## Summary
- Apply shared form styles and updated layout to Full Monty wizard
- Refactor wizard steps to use standardized form groups, currency/percent inputs, and risk cards
- Improve navigation with inline validation and accessible progress controls

## Testing
- `node --check fullMontyWizard.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897560f498083338cd21ab0c4b320bc