### PR TITLE
Refactor Full Monty wizard UI and flow

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -51,6 +51,36 @@
     .input-wrap.prefix .unit{left:.5rem;}
     .input-wrap.suffix .unit{right:.5rem;}
     .error{color:var(--danger);margin-top:.5rem;}
+
+    /* List step buttons */
+    .btn-list-add{
+      display:inline-flex; justify-content:center; align-items:center;
+      width:100%;
+      background:#555; color:#fff; font-weight:700; border-radius:12px;
+      padding:.8rem 1rem; transition: transform .2s, box-shadow .2s, filter .2s;
+      cursor:pointer; border:none;
+    }
+    .btn-list-add:hover, .btn-list-add:focus-visible{
+      transform: scale(1.01);
+      box-shadow: 0 0 16px rgba(255,255,255,.08);
+      outline:2px solid transparent;
+    }
+
+    .btn-row-remove{
+      background:transparent; color:#ff8a8a; border:1px solid rgba(255,255,255,.15);
+      padding:.45rem .7rem; border-radius:10px; font-weight:700; cursor:pointer;
+      margin-top:.4rem;
+    }
+    .btn-row-remove:hover, .btn-row-remove:focus-visible{
+      color:#fff; background:rgba(255,0,0,.12); border-color: rgba(255,0,0,.35);
+      outline:2px solid transparent;
+    }
+
+    /* Optional: row grouping look */
+    .list-wrap .asset-row{
+      background:#353535; border:1px solid rgba(255,255,255,.08);
+      border-radius:12px; padding:.8rem; margin-bottom:.8rem;
+    }
     @keyframes slideInLeft{from{transform:translateX(-40px);opacity:0}to{transform:none;opacity:1}}
     @keyframes slideInRight{from{transform:translateX(40px);opacity:0}to{transform:none;opacity:1}}
     #fmStepContainer.anim-left{animation:slideInLeft .25s ease-out both}


### PR DESCRIPTION
## Summary
- rework list step renderer to append and remove rows without full re-render
- drop standalone rental income step and derive rent from property rows
- lock goal to percent and update step progress/labels
- style add/remove buttons for list steps

## Testing
- `node --check fullMontyWizard.js`


------
https://chatgpt.com/codex/tasks/task_e_6898ace7bc308333a60251d36dd7ddf6