### PR TITLE
Unify currency and percent inputs

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="favicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/inputs.css">
   <style>
     :root{
       --accent:#c000ff;
@@ -16,8 +17,6 @@
     *{box-sizing:border-box}
     body{font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh;padding:1rem;margin:0;}
     button{padding:.5rem .9rem;font-weight:700;font-size:1rem;border:none;border-radius:8px;cursor:pointer;color:#fff;background:#555;margin:.3rem 0;min-height:2.5rem;}
-    .wizard-controls > button{background:linear-gradient(135deg,#00ff88,#0099ff);border-radius:50px;transition:transform .25s,box-shadow .25s;min-height:2.75rem;}
-    .wizard-controls > button:hover{transform:scale(1.03);box-shadow:0 0 22px rgba(0,255,136,.8);}
     .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;}
     .modal.hidden{display:none;}
     #fullMontyModal .wizard-card{display:flex;flex-direction:column;max-width:640px;width:calc(100% - 2rem);max-height:86vh;overflow:hidden;border-radius:16px;padding:2rem;background:#2a2a2a;}
@@ -27,11 +26,6 @@
     #fmProgressBar{height:6px;background:#ddd;border-radius:3px;margin:0 24px 12px;}
     #fmProgressFill{height:100%;width:0;background:var(--accent);border-radius:3px;transition:width .25s ease;}
     #fmDots{display:flex;justify-content:center;gap:8px;}
-    button.wizDot{
-      padding:0 !important;margin:0;border:none;min-height:0 !important;
-      width:14px;height:14px;display:inline-block;border-radius:50%;background:#888;cursor:pointer;line-height:0;background-image:none !important;aspect-ratio:1/1;
-    }
-    button.wizDot.active,button.wizDot:focus-visible{background:var(--accent);outline:none;}
     .wizard-controls{display:flex;justify-content:space-between;margin-top:auto;}
     #fmStepContainer{overflow:auto;-webkit-overflow-scrolling:touch;padding-right:.25rem;}
     .form{display:flex;flex-direction:column;gap:1rem;}
@@ -44,37 +38,7 @@
     input[type=date],input[type=number],input[type=text],select{width:100%;padding:.55rem .7rem;border:1px solid transparent;border-radius:8px;background:#404040;color:#fff;}
     input::placeholder{color:#aaa;}
     input:focus,select:focus{outline:none;border-color:var(--glow);box-shadow:0 0 0 3px rgba(0,255,136,.25);}
-    .input-wrap{position:relative;display:block;}
-    .input-wrap.prefix input{padding-left:1.6rem;}
-    .input-wrap.suffix input{padding-right:1.6rem;}
-    .input-wrap .unit{position:absolute;top:50%;transform:translateY(-50%);color:#bbb;font-size:.9em;pointer-events:none;}
-    .input-wrap.prefix .unit{left:.5rem;}
-    .input-wrap.suffix .unit{right:.5rem;}
     .error{color:var(--danger);margin-top:.5rem;}
-
-    /* List step buttons */
-    .btn-list-add{
-      display:inline-flex; justify-content:center; align-items:center;
-      width:100%;
-      background:#555; color:#fff; font-weight:700; border-radius:12px;
-      padding:.8rem 1rem; transition: transform .2s, box-shadow .2s, filter .2s;
-      cursor:pointer; border:none;
-    }
-    .btn-list-add:hover, .btn-list-add:focus-visible{
-      transform: scale(1.01);
-      box-shadow: 0 0 16px rgba(255,255,255,.08);
-      outline:2px solid transparent;
-    }
-
-    .btn-row-remove{
-      background:transparent; color:#ff8a8a; border:1px solid rgba(255,255,255,.15);
-      padding:.45rem .7rem; border-radius:10px; font-weight:700; cursor:pointer;
-      margin-top:.4rem;
-    }
-    .btn-row-remove:hover, .btn-row-remove:focus-visible{
-      color:#fff; background:rgba(255,0,0,.12); border-color: rgba(255,0,0,.35);
-      outline:2px solid transparent;
-    }
 
     /* Optional: row grouping look */
     .list-wrap .asset-row{

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -4,6 +4,7 @@
 // and Personal Balance Sheet).
 
 import { animate, addKeyboardNav } from './wizardCore.js';
+import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
 
 // ───────────────────────────────────────────────────────────────
 // Data store and helpers
@@ -93,50 +94,6 @@ export function removeRow(listKey, id) {
 
 function q(id) { return document.getElementById(id); }
 
-function numFromInput(inp) {
-  const v = inp.value.trim();
-  if (v === '') return null;
-  const n = +v.replace(/[^0-9.-]/g, '');
-  return isNaN(n) ? null : n;
-}
-
-function percentInput({ id, value = '', min = 0, max = 100 }) {
-  const wrap = document.createElement('div');
-  wrap.className = 'input-wrap suffix';
-  const inp = document.createElement('input');
-  inp.type = 'number';
-  inp.id = id;
-  inp.min = min;
-  inp.max = max;
-  inp.step = '0.1';
-  inp.value = value;
-  inp.addEventListener('input', () => {
-    inp.value = inp.value.replace(/[^0-9.-]/g, '');
-  });
-  const span = document.createElement('span');
-  span.textContent = '%';
-  span.className = 'unit';
-  wrap.append(inp, span);
-  return wrap;
-}
-
-function currencyInput({ id, value = '', min = 0 }) {
-  const wrap = document.createElement('div');
-  wrap.className = 'input-wrap prefix';
-  const inp = document.createElement('input');
-  inp.type = 'number';
-  inp.id = id;
-  if (min != null) inp.min = min;
-  inp.value = value;
-  inp.addEventListener('input', () => {
-    inp.value = inp.value.replace(/[^0-9.-]/g, '');
-  });
-  const span = document.createElement('span');
-  span.textContent = '€';
-  span.className = 'unit';
-  wrap.append(span, inp);
-  return wrap;
-}
 
 function formGroup(id, labelText, input) {
   const g = document.createElement('div');
@@ -214,7 +171,9 @@ function makeListStepRenderer(
           fieldEl = percentInput({ id, value: row[f.key] ?? '' });
           const input = fieldEl.querySelector('input');
           input.addEventListener('input', () => {
-            row[f.key] = numFromInput(input) || 0;
+            const v = clampPercent(numFromInput(input));
+            input.value = v ?? '';
+            row[f.key] = v ?? 0;
           });
         } else {
           fieldEl = document.createElement('input');
@@ -282,34 +241,26 @@ function makeListStepRenderer(
 // Step 3 – percent-only goal
 function renderStepGoal(container){
   const s = getStore();
-  setStore({ goalType: 'percent' }); // hard lock
+  setStore({ goalType: 'percent' });
 
-  container.innerHTML = `
-    <div class="form">
-      <div class="form-group">
-        <label for="incomePercent">Income you will need at retirement</label>
-        <div class="input-wrap suffix">
-          <input id="incomePercent" type="number" inputmode="decimal" min="0" max="100" step="0.1"
-                 value="${s.incomePercent ?? 70}">
-          <span class="unit">%</span>
-        </div>
-        <div class="help">We’ll target this share of your gross income.</div>
-      </div>
-    </div>
-  `;
-  const pct = container.querySelector('#incomePercent');
-  pct.addEventListener('input', () => {
-    let v = parseFloat(pct.value);
-    if (Number.isNaN(v)) v = 0;
-    if (v < 0) v = 0; if (v > 100) v = 100;
-    pct.value = v;
-    setStore({ incomePercent: v, goalType: 'percent' });
+  container.innerHTML = '';
+  const form = document.createElement('div'); form.className='form';
+
+  const pctWrap = percentInput({ id:'incomePercent', value: s.incomePercent ?? 70 });
+  pctWrap.querySelector('input').addEventListener('input', (e)=>{
+    const v = clampPercent(numFromInput(e.target)) ?? 0;
+    e.target.value = v; // clamp visually
+    setStore({ incomePercent: v, goalType: 'percent', retireSpend: null });
   });
+
+  form.appendChild(formGroup('incomePercent', 'Income you will need at retirement', pctWrap));
+  const help = document.createElement('div'); help.className='help'; help.textContent='We’ll target this share of your gross income.';
+  form.appendChild(help);
+  container.appendChild(form);
 }
 renderStepGoal.validate = () => {
   const v = getStore().incomePercent;
-  return (typeof v === 'number' && v >= 0 && v <= 100)
-    ? { ok: true } : { ok: false, message: 'Enter a % between 0 and 100.' };
+  return (typeof v === 'number' && v >= 0 && v <= 100) ? { ok:true } : { ok:false, message:'Enter a % between 0 and 100.' };
 };
 // Step 5–9 renderers
 const renderStepHomes = makeListStepRenderer('homes', {

--- a/fy-money-calculator.html
+++ b/fy-money-calculator.html
@@ -10,6 +10,7 @@
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
     rel="stylesheet"
   />
+  <link rel="stylesheet" href="styles/inputs.css">
 
   <style>
     * { box-sizing: border-box }
@@ -59,15 +60,10 @@
       font-weight: 700;
       font-size: 1rem;
       border: none;
-      border-radius: 50px;
+      border-radius: 8px;
       cursor: pointer;
-      color: #1a1a1a;
-      background: linear-gradient(135deg, #00ff88, #0099ff);
-      transition: transform .25s, box-shadow .25s;
-    }
-    button:hover {
-      transform: scale(1.03);
-      box-shadow: 0 0 22px rgba(0, 255, 136, .8);
+      color: #fff;
+      background: #555;
     }
 
     #results {
@@ -84,12 +80,6 @@
     }
 
     .error { color: #ff5c5c; margin-top: .5rem }
-    .input-wrap { position: relative; display: inline-block; }
-    .input-wrap.prefix  input { padding-left: 1.6rem; }
-    .input-wrap.suffix  input { padding-right: 1.6rem; }
-    .input-wrap .unit { position: absolute; top: 50%; transform: translateY(-50%); color: #bbb; font-size: 0.9em; pointer-events: none; }
-    .input-wrap.prefix  .unit { left: 0.5rem; }
-    .input-wrap.suffix  .unit { right: 0.5rem; }
 
     .warning-block {
       background: #444;
@@ -192,23 +182,6 @@
       gap: 8px;                   /* even spacing */
     }
 
-    /* one dot / step selector */
-    button.wizDot {
-      width: 14px;
-      height: 14px;
-      padding: 0;
-      line-height: 0;
-      border: none;
-      border-radius: 50%;
-      background: #888;
-      background-image: none !important;     /* cancel global gradient */
-      cursor: pointer;
-    }
-    button.wizDot.active,
-    button.wizDot:focus-visible {
-      background: #00aaff;
-    }
-
     /* FOOTER ============================================= */
     .wizard-controls {
       display: flex;
@@ -285,11 +258,17 @@ canvas {
         <input type="hidden" id="partnerExists" name="partnerExists" />
         <div class="form-group">
           <label for="grossIncome">Gross annual income (€)</label>
-          <input type="number" id="grossIncome" required />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="grossIncome" required />
+          </div>
         </div>
         <div class="form-group">
           <label for="incomePercent">% of income needed in retirement</label>
-          <input type="number" id="incomePercent" step="0.1" min="0" max="100" value="70" required />
+          <div class="input-wrap suffix">
+            <input type="number" id="incomePercent" min="0" max="100" step="0.1" value="70" required />
+            <span class="unit">%</span>
+          </div>
         </div>
         <div class="form-group checkbox-group">
           <div>
@@ -365,7 +344,10 @@ canvas {
 
         <div class="form-group">
           <label for="rentalIncome">Annual rental income today (€)</label>
-          <input type="number" id="rentalIncome" placeholder="e.g. 12000" />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="rentalIncome" placeholder="e.g. 12000" />
+          </div>
         </div>
         <div class="form-group checkbox-group">
           <div>
@@ -375,7 +357,10 @@ canvas {
         </div>
        <div id="db-group" class="form-group" style="display:none;">
          <label for="dbPension">DB pension annual amount at retirement (€)</label>
-         <input type="number" id="dbPension" placeholder="e.g. 20000" />
+         <div class="input-wrap prefix">
+           <span class="unit">€</span>
+           <input type="number" id="dbPension" placeholder="e.g. 20000" />
+         </div>
           <!-- When DB pension box is ticked we need to know when it kicks in -->
           <label for="dbStartAge" style="margin-top:.8rem;">DB pension starts at age</label>
           <input type="number" id="dbStartAge"

--- a/fyMoneyCalculator.js
+++ b/fyMoneyCalculator.js
@@ -1,4 +1,5 @@
 import { drawBanner, getBannerHeight } from './pdfWarningHelpers.js';
+import { numFromInput, clampPercent } from './ui-inputs.js';
 const setHTML = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML = html; };
 const CPI = 0.023;
 const STATE_PENSION = 15044;
@@ -55,6 +56,10 @@ return (ref - d) / (1000 * 60 * 60 * 24 * 365.25);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+document.getElementById('incomePercent').addEventListener('input', e=>{
+  const v = clampPercent(numFromInput(e.target)) ?? 0;
+  e.target.value = v;
+});
 document.getElementById('partnerStatePension').addEventListener('change', e => {
   document.getElementById('partner-dob-group').style.display = e.target.checked ? 'block' : 'none';
 });
@@ -88,8 +93,8 @@ try {
   document.getElementById('sftModal').style.display = 'none';
   setHTML('calcWarnings', '');
   let sftWarningHTML = '';
-  const gross = +document.getElementById('grossIncome').value || 0;
-  const pctNeed = (+document.getElementById('incomePercent').value || 0) / 100;
+  const gross = numFromInput(document.getElementById('grossIncome')) || 0;
+  const pctNeed = (clampPercent(numFromInput(document.getElementById('incomePercent'))) || 0) / 100;
   const includeSP = document.getElementById('statePension').checked;
   const includePartnerSP = document.getElementById('partnerStatePension').checked;
   const dob = new Date(document.getElementById('dob').value);
@@ -100,9 +105,9 @@ try {
   // ← Read the selected growth-rate card
   const gRate = +document.querySelector('input[name="growthRate"]:checked').value;
 
- const rentalToday = +document.getElementById('rentalIncome').value || 0;
+ const rentalToday = numFromInput(document.getElementById('rentalIncome')) || 0;
  const hasDb = document.getElementById('hasDb').checked;
- const dbAnnual = hasDb ? (+document.getElementById('dbPension').value || 0) : 0;
+ const dbAnnual = hasDb ? (numFromInput(document.getElementById('dbPension')) || 0) : 0;
  const dbStartAge = hasDb
    ? (+document.getElementById('dbStartAge').value || retireAge)
    : Infinity;
@@ -532,12 +537,12 @@ danger : el.classList.contains('danger')
 }
 
 function gatherData(requiredPot, retirementYear, sftText) {
-const grossIncome = +document.getElementById('grossIncome').value || 0;
-const rentalIncome = +document.getElementById('rentalIncome').value || 0;
-const dbPension = +document.getElementById('dbPension').value || 0;
+const grossIncome = numFromInput(document.getElementById('grossIncome')) || 0;
+const rentalIncome = numFromInput(document.getElementById('rentalIncome')) || 0;
+const dbPension = numFromInput(document.getElementById('dbPension')) || 0;
 const inputs = {
   grossIncome,
-  incomePercent: +document.getElementById('incomePercent').value || 0,
+  incomePercent: clampPercent(numFromInput(document.getElementById('incomePercent'))) || 0,
   statePension: document.getElementById('statePension').checked,
   partnerStatePension: document.getElementById('partnerStatePension').checked,
   partnerExists: document.getElementById('partnerExists').value === 'true',

--- a/pension-projection.html
+++ b/pension-projection.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pension Growth Projection</title>
  <link rel="icon" type="image/png" href="favicon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+ <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/inputs.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
 
   <style>
@@ -21,17 +22,10 @@
     input::placeholder{color:#aaa}
     .two-col{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
     .radio-group{display:flex;gap:1rem;flex-wrap:wrap}
-    button{margin-top:1rem;width:100%;padding:.8rem 1rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);transition:transform .25s,box-shadow .25s}
-    button:hover{transform:scale(1.03);box-shadow:0 0 22px rgba(0,255,136,.8)}
+    button{margin-top:1rem;width:100%;padding:.8rem 1rem;font-weight:700;font-size:1rem;border:none;border-radius:8px;cursor:pointer;color:#fff;background:#555}
     #results{margin-top:2rem;background:#333;border-radius:12px;padding:1rem 1.2rem}
     #chart-container{margin-top:1.5rem}
     .error{color:#ff5c5c;margin-top:.5rem}
-    .input-wrap { position: relative; display: inline-block; }
-    .input-wrap.prefix  input { padding-left: 1.6rem; }
-    .input-wrap.suffix  input { padding-right: 1.6rem; }
-    .input-wrap .unit { position: absolute; top: 50%; transform: translateY(-50%); color: #bbb; font-size: 0.9em; pointer-events: none; }
-    .input-wrap.prefix  .unit { left: 0.5rem; }
-    .input-wrap.suffix  .unit { right: 0.5rem; }
     .warning-block{
       background:#444;
       border-left:4px solid #ffa500;
@@ -114,23 +108,6 @@
   display: flex;
   justify-content: center;
   gap: 8px;                   /* even spacing */
-}
-
-/* one dot / step selector */
-button.wizDot {
-  width: 14px;
-  height: 14px;
-  padding: 0;
-  line-height: 0;
-  border: none;
-  border-radius: 50%;
-  background: #888;
-  background-image: none !important;     /* cancel global gradient */
-  cursor: pointer;
-}
-button.wizDot.active,
-button.wizDot:focus-visible {
-  background: #00aaff;
 }
 
 /* FOOTER ============================================= */
@@ -219,26 +196,44 @@ button.wizDot:focus-visible {
       <form id="proj-form" autocomplete="off">
         <div class="form-group">
           <label for="salary">Gross salary (€) <small>(max €115 000 is used in calculations)</small></label>
-          <input type="number" id="salary" required />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="salary" required />
+          </div>
         </div>
 
         <div class="form-group">
           <label for="currentValue">Current pension value (€)</label>
-          <input type="number" id="currentValue" required />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="currentValue" required />
+          </div>
         </div>
 
         <div class="form-group">
           <label for="personalContrib">Your annual pension contribution (€)</label>
-          <input type="number" id="personalContrib" placeholder="Leave blank if using % of salary" />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="personalContrib" placeholder="Leave blank if using % of salary" />
+          </div>
           <label for="personalPct" class="sub-label">% of salary</label>
-          <input type="number" id="personalPct" step="0.1" placeholder="Leave blank if € used" />
+          <div class="input-wrap suffix">
+            <input type="number" id="personalPct" step="0.1" placeholder="Leave blank if € used" />
+            <span class="unit">%</span>
+          </div>
         </div>
 
         <div class="form-group">
           <label for="employerContrib">Employer annual contribution (€)</label>
-          <input type="number" id="employerContrib" placeholder="Leave blank if using % of salary" />
+          <div class="input-wrap prefix">
+            <span class="unit">€</span>
+            <input type="number" id="employerContrib" placeholder="Leave blank if using % of salary" />
+          </div>
           <label for="employerPct" class="sub-label">% of salary</label>
-          <input type="number" id="employerPct" step="0.1" placeholder="Leave blank if € used" />
+          <div class="input-wrap suffix">
+            <input type="number" id="employerPct" step="0.1" placeholder="Leave blank if € used" />
+            <span class="unit">%</span>
+          </div>
         </div>
 
         <div class="form-group">

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -1,4 +1,5 @@
 import { drawBanner, getBannerHeight } from './pdfWarningHelpers.js';
+import { numFromInput, clampPercent } from './ui-inputs.js';
 const MAX_SALARY_CAP = 115000;
 const AGE_BANDS = [
   { max: 29,  pct: 0.15 },
@@ -78,6 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const handlePct = () => {
+      const v = clampPercent(numFromInput(pct));
+      if(v != null) pct.value = v;
       if (pct.value !== '') {
         euro.value = '';
         euro.disabled = true;
@@ -379,14 +382,14 @@ document.getElementById('proj-form').addEventListener('submit', e => {
   try {
     document.getElementById('calcWarnings').innerHTML = '';
     // Inputs
-    const salaryRaw  = +document.getElementById('salary').value;
+    const salaryRaw  = numFromInput(document.getElementById('salary')) || 0;
     salaryCapped    = Math.min(salaryRaw, MAX_SALARY_CAP);
-    currentPv       = +document.getElementById('currentValue').value;
-    const personalRaw = +document.getElementById('personalContrib').value || 0;
-const personalPct = (+document.getElementById('personalPct').value || 0) / 100;
+    currentPv       = numFromInput(document.getElementById('currentValue')) || 0;
+    const personalRaw = numFromInput(document.getElementById('personalContrib')) || 0;
+const personalPct = (clampPercent(numFromInput(document.getElementById('personalPct'))) || 0) / 100;
 
-const employerRaw = +document.getElementById('employerContrib').value || 0;
-const employerPct = (+document.getElementById('employerPct').value || 0) / 100;
+const employerRaw = numFromInput(document.getElementById('employerContrib')) || 0;
+const employerPct = (clampPercent(numFromInput(document.getElementById('employerPct'))) || 0) / 100;
 employerCalc      = employerRaw > 0 ? employerRaw : salaryRaw * employerPct;
 
     retireAge       = +document.getElementById('retireAge').value;
@@ -557,12 +560,12 @@ if (projValue > sftLimit) {
 
     function gatherData(value, year, sftText, personalAnnual, employerAnnual, maxValue) {
       const inputs = {
-        salary: +document.getElementById('salary').value || 0,
-        currentValue: +document.getElementById('currentValue').value || 0,
-        personalContrib: +document.getElementById('personalContrib').value || 0,
-        personalPct: +document.getElementById('personalPct').value || 0,
-        employerContrib: +document.getElementById('employerContrib').value || 0,
-        employerPct: +document.getElementById('employerPct').value || 0,
+        salary: numFromInput(document.getElementById('salary')) || 0,
+        currentValue: numFromInput(document.getElementById('currentValue')) || 0,
+        personalContrib: numFromInput(document.getElementById('personalContrib')) || 0,
+        personalPct: clampPercent(numFromInput(document.getElementById('personalPct'))) || 0,
+        employerContrib: numFromInput(document.getElementById('employerContrib')) || 0,
+        employerPct: clampPercent(numFromInput(document.getElementById('employerPct'))) || 0,
         dob: document.getElementById('dob').value,
         retireAge: +document.getElementById('retireAge').value || 0,
         growth: +document.querySelector('input[name="growth"]:checked').value

--- a/personal-balance-sheet.html
+++ b/personal-balance-sheet.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="favicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="PrintStyles.css" />
+  <link rel="stylesheet" href="styles/inputs.css" />
 
   <style>
     /* ========== EXISTING WIZARD STYLES (unchanged) ========== */
@@ -23,7 +24,7 @@
       min-height:100vh;
       padding:calc(env(safe-area-inset-top,0) + 2rem) 1rem calc(env(safe-area-inset-bottom,0) + 2rem);
     }
-    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:50px;cursor:pointer;color:#1a1a1a;background:linear-gradient(135deg,#00ff88,#0099ff);margin:.3rem 0;min-height:2.75rem}
+    button{padding:.8rem 1.2rem;font-weight:700;font-size:1rem;border:none;border-radius:8px;cursor:pointer;color:#fff;background:#555;margin:.3rem 0;min-height:2.75rem}
     .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:flex;justify-content:center;align-items:flex-start;overflow-y:auto;padding:1rem 0;z-index:9999}
     .modal.hidden{display:none}
     .wizard-card{display:flex;flex-direction:column;width:90%;max-width:420px;background:#2a2a2a;border-radius:16px;padding:2rem;margin:auto 0}
@@ -32,29 +33,7 @@
     #wizProgressBar{height:6px;background:#ddd;border-radius:3px;margin:0 24px 12px}
     #wizProgressFill{height:100%;width:0;background:#00aaff;border-radius:3px;transition:width .25s ease}
     #wizDots{display:flex;gap:.35rem;justify-content:center}
-    button.wizDot{
-      width:.75rem;
-      height:.75rem;
-      min-height:0;
-      aspect-ratio:1/1;
-      border-radius:50%;
-      flex:0 0 auto;
-      border:none;
-      background:#888;
-      cursor:pointer;
-      padding:0;
-      margin:0;
-      transition:transform .25s,box-shadow .25s;
-    }
-    button.wizDot:hover{
-      box-shadow:0 0 12px rgba(0,255,136,.6);
-      transform:scale(1.2);
-    }
-    button.wizDot.active,button.wizDot:focus-visible{background:#00aaff}
     .wizard-controls{display:flex;justify-content:space-between;margin-top:auto}
-    .currency{position:relative;display:inline-block}
-    .currency input{padding-left:1.4rem;width:100%;background:#404040;border:none;border-radius:8px;color:#fff}
-    .currency::before{content:'€';position:absolute;left:.4rem;top:50%;transform:translateY(-50%);color:#bbb}
     label{display:block;margin-top:1rem}
     select,input[type=text],input[type=number]{width:100%;padding:.55rem .7rem;border:none;border-radius:8px;background:#404040;color:#fff}
     .error{color:#ff4d4f;font-size:.9rem;margin-top:4px}

--- a/styles/inputs.css
+++ b/styles/inputs.css
@@ -1,0 +1,93 @@
+:root{
+  --field-bg:#404040;
+  --field-ink:#fff;
+  --field-muted:#bbb;
+  --field-border:transparent;
+  --focus:#00ff88;
+  --focus-ring:0 0 0 3px rgba(0,255,136,.25);
+}
+
+/* Wrapper that visually binds unit + input into one control */
+.input-wrap{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  background: var(--field-bg);
+  color: var(--field-ink);
+  border: 1px solid var(--field-border);
+  border-radius: 10px;
+  padding: .55rem .7rem;
+  min-width: 8ch;
+}
+.input-wrap input{
+  border:0;
+  background:transparent;
+  color:inherit;
+  font: inherit;
+  outline: none;
+  min-width: 6ch;
+}
+.input-wrap:focus-within{
+  border-color: var(--focus);
+  box-shadow: var(--focus-ring);
+}
+.input-wrap input::placeholder{ color:#aaa; }
+
+/* Prefix € */
+.input-wrap.prefix{ padding-left: 1.8rem; }
+.input-wrap.prefix .unit{
+  position:absolute; left:.6rem; top:50%; transform: translateY(-50%);
+  color: var(--field-muted);
+}
+
+/* Suffix % */
+.input-wrap.suffix{ padding-right: 1.8rem; }
+.input-wrap.suffix .unit{
+  position:absolute; right:.6rem; top:50%; transform: translateY(-50%);
+  color: var(--field-muted);
+}
+
+/* Optional sizes */
+.input-sm input{ min-width:5ch; }
+.input-lg input{ min-width:10ch; }
+
+/* Wizard dots must remain true circles (avoid global button bleed) */
+button.wizDot{
+  padding:0 !important; margin:0; border:none; min-height:0 !important;
+  width:14px; height:14px; display:inline-block; border-radius:50%;
+  background:#888; cursor:pointer; line-height:0; background-image:none !important; aspect-ratio:1/1;
+}
+button.wizDot.active, button.wizDot:focus-visible{ background:#c000ff; outline:none; }
+
+/* Add/remove buttons inside list steps should not inherit big gradient */
+.btn-list-add{
+  display:flex; justify-content:center; align-items:center; width:100%;
+  background:#555; color:#fff; font-weight:700; border-radius:12px;
+  padding:.8rem 1rem; cursor:pointer; border:none;
+  transition: transform .2s, box-shadow .2s;
+}
+.btn-list-add:hover, .btn-list-add:focus-visible{
+  transform: scale(1.01);
+  box-shadow: 0 0 16px rgba(255,255,255,.08);
+  outline:2px solid transparent;
+}
+.btn-row-remove{
+  background:transparent; color:#ff8a8a; border:1px solid rgba(255,255,255,.15);
+  padding:.45rem .7rem; border-radius:10px; font-weight:700; cursor:pointer;
+}
+.btn-row-remove:hover, .btn-row-remove:focus-visible{
+  color:#fff; background:rgba(255,0,0,.12); border-color:rgba(255,0,0,.35);
+  outline:2px solid transparent;
+}
+
+/* On wizard pages only */
+.wizard-controls > button{
+  background:linear-gradient(135deg,#00ff88,#0099ff);
+  border-radius:50px;
+  transition:transform .25s,box-shadow .25s;
+  min-height:2.75rem;
+}
+.wizard-controls > button:hover{
+  transform:scale(1.03);
+  box-shadow:0 0 22px rgba(0,255,136,.8);
+}

--- a/ui-inputs.js
+++ b/ui-inputs.js
@@ -1,0 +1,29 @@
+// ui-inputs.js
+export function currencyInput({ id, value = '', placeholder = '' } = {}){
+  const wrap = document.createElement('div'); wrap.className = 'input-wrap prefix';
+  const unit = document.createElement('span'); unit.className='unit'; unit.textContent='€';
+  const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
+  inp.inputMode='decimal'; inp.placeholder=placeholder;
+  if(value !== '' && value != null) inp.value=value;
+  wrap.append(unit, inp);
+  return wrap;
+}
+export function percentInput({ id, value = '', placeholder = '' } = {}){
+  const wrap = document.createElement('div'); wrap.className = 'input-wrap suffix';
+  const unit = document.createElement('span'); unit.className='unit'; unit.textContent='%';
+  const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
+  inp.inputMode='decimal'; inp.min='0'; inp.max='100'; inp.step='0.1'; inp.placeholder=placeholder;
+  if(value !== '' && value != null) inp.value=value;
+  wrap.append(inp, unit);
+  return wrap;
+}
+export function numFromInput(inputEl){
+  const v = parseFloat(inputEl.value);
+  return Number.isNaN(v) ? null : v;
+}
+export function clampPercent(n){
+  if(n == null) return null;
+  if(n < 0) return 0;
+  if(n > 100) return 100;
+  return +n;
+}


### PR DESCRIPTION
## Summary
- Add shared input styles and helpers for currency and percent fields
- Apply consistent "€"/"%" wrappers and clamped parsing across calculators
- Scope wizard styling so dots stay circular and nav buttons keep gradients

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0ff095083338c148ea38371e8bd