### PR TITLE
Add persistence, zero-clear inputs, and step subtitles

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -26,6 +26,24 @@
     #fmProgressBar{height:6px;background:#ddd;border-radius:3px;margin:0 24px 12px;}
     #fmProgressFill{height:100%;width:0;background:var(--accent);border-radius:3px;transition:width .25s ease;}
     #fmDots{display:flex;justify-content:center;gap:8px;}
+    #fmTitle{
+      margin:.25rem 0 0;
+      font-weight:800;
+      font-size:1.05rem;
+      color:#fff;
+      text-align:center;
+    }
+    .btn-list-add{
+      display:flex;justify-content:center;align-items:center;width:100%;
+      background:#555;color:#fff;font-weight:700;border-radius:12px;
+      padding:.9rem 1rem;cursor:pointer;border:none;
+      transition:transform .2s,box-shadow .2s,filter .2s;
+    }
+    .btn-list-add:hover, .btn-list-add:focus-visible{
+      transform:translateY(-1px);
+      box-shadow:0 0 16px rgba(255,255,255,.08);
+      outline:2px solid transparent;
+    }
     .wizard-controls{display:flex;justify-content:space-between;margin-top:auto;}
     #fmStepContainer{overflow:auto;-webkit-overflow-scrolling:touch;padding-right:.25rem;}
     .form{display:flex;flex-direction:column;gap:1rem;}
@@ -78,6 +96,7 @@
         <h3 id="fmProgress"></h3>
         <div id="fmProgressBar"><div id="fmProgressFill"></div></div>
         <div id="fmDots"></div>
+        <h3 id="fmTitle"></h3>
       </div>
       <div id="fmStepContainer"></div>
       <div class="wizard-controls">

--- a/ui-inputs.js
+++ b/ui-inputs.js
@@ -1,20 +1,44 @@
 // ui-inputs.js
+export function attachZeroClear(inputEl, { clampPercent: doClamp = false } = {}){
+  inputEl.addEventListener('focus', () => {
+    if (inputEl.value === '' || inputEl.value === '0' || inputEl.value === '0.0') {
+      inputEl.select?.();
+      inputEl.value = '';
+    }
+  });
+  inputEl.addEventListener('blur', () => {
+    if (inputEl.value.trim() === '') inputEl.value = '';
+    if (doClamp) {
+      let v = parseFloat(inputEl.value);
+      if (!Number.isNaN(v)) {
+        if (v < 0) v = 0;
+        if (v > 100) v = 100;
+        inputEl.value = v;
+      }
+    }
+  });
+}
+
 export function currencyInput({ id, value = '', placeholder = '' } = {}){
   const wrap = document.createElement('div'); wrap.className = 'input-wrap prefix';
   const unit = document.createElement('span'); unit.className='unit'; unit.textContent='€';
   const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
-  inp.inputMode='decimal'; inp.placeholder=placeholder;
-  if(value !== '' && value != null) inp.value=value;
+  inp.inputMode='decimal'; inp.placeholder = placeholder || '0';
+  if (value !== null && value !== undefined && value !== 0) inp.value = String(value);
   wrap.append(unit, inp);
+  attachZeroClear(inp);
   return wrap;
 }
+
 export function percentInput({ id, value = '', placeholder = '' } = {}){
   const wrap = document.createElement('div'); wrap.className = 'input-wrap suffix';
   const unit = document.createElement('span'); unit.className='unit'; unit.textContent='%';
   const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
-  inp.inputMode='decimal'; inp.min='0'; inp.max='100'; inp.step='0.1'; inp.placeholder=placeholder;
-  if(value !== '' && value != null) inp.value=value;
+  inp.inputMode='decimal'; inp.min='0'; inp.max='100'; inp.step='0.1';
+  inp.placeholder = placeholder || '0';
+  if (value !== null && value !== undefined && value !== 0) inp.value = String(value);
   wrap.append(inp, unit);
+  attachZeroClear(inp, { clampPercent: true });
   return wrap;
 }
 export function numFromInput(inputEl){


### PR DESCRIPTION
## Summary
- Show per-step titles under the progress bar for the Full Monty wizard
- Add zero-clear currency and percent inputs and persist wizard data via localStorage
- Improve list steps: keep empty rows, save changes automatically, and style the add button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7c6fd648333ab8ab6e84986692f