### PR TITLE
Refactor Full Monty asset and debt inputs into grouped buckets

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -48,7 +48,7 @@
 
     /* Checkbox row */
     .control.control-switch{
-      display:flex; align-items:center; gap:.6rem; margin:.3rem 0 .4rem;
+      display:flex; align-items:center; gap:.6rem; margin:.3rem 0 .3rem;
     }
     .control.control-switch input[type="checkbox"]{
       accent-color:#00aaff;
@@ -77,6 +77,7 @@
       <div class="wiz-header">
         <h3 id="fmProgress"></h3>
         <div id="fmProgressBar"><div id="fmProgressFill"></div></div>
+        <h3 id="fmTitle"></h3>
         <div id="fmDots"></div>
       </div>
       <div id="fmStepContainer"></div>

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -46,15 +46,43 @@ const fullMontyStore = {
   dbStartAgePartner: null,
   statePensionPartner: false,
 
-  // ASSETS (split into mini-steps)
-  homes: [],        // [{ id, name, value, hasRent?: boolean, rentAmount?: number }]
-  cashLike: [],     // [{id,name,value}]
-  investments: [],  // [{id,name,value}]
-  rentProps: [],    // [{id,name,value,mortgageBalance?,grossRent?}]
-  valuables: [],    // [{id,name,value}]
+  // homes you live in / holiday places
+  homes: {
+    familyHome: { value: 0, hasRent: false, rentAmount: 0 },
+    holidayHome: { value: 0, hasRent: false, rentAmount: 0 }
+  },
 
-  // debts
-  liabilities: [],  // [{id,name,balance,rate?}]
+  // cash-like / liquidity
+  liquidity: {
+    currentAccount: 0,
+    cashSavings: 0,
+    moneyMarket: 0,
+    bond100: 0,
+    otherInstant: 0
+  },
+
+  // non-pension investments
+  investments: {
+    etfIndexFunds: 0,
+    mixedEquityFunds: 0,
+    brokerageCash: 0,
+    otherInvestments: 0
+  },
+
+  // properties for rent
+  rentProps: [],   // [{id,name,value,mortgageBalance,grossRent}]
+
+  // liabilities
+  liabilities: {
+    mortgageHome: { balance: 0, rate: 0 },
+    mortgageRental: { balance: 0, rate: 0 },
+    creditCard: { balance: 0, rate: 0 },
+    personalLoan: { balance: 0, rate: 0 },
+    carFinance: { balance: 0, rate: 0 },
+    studentLoan: { balance: 0, rate: 0 },
+    taxOwed: { balance: 0, rate: 0 },
+    otherDebt: { balance: 0, rate: 0 }
+  },
 
   // risk profile
   growthProfile: 0.05,
@@ -63,6 +91,48 @@ const fullMontyStore = {
   cpiRate: 2.3,         // fixed, not user-editable
   sftAwareness: true    // fixed, not user-editable
 };
+
+const LS_KEY = 'fullMontyStore';
+let saveTimer;
+
+function saveStore(){
+  try{ localStorage.setItem(LS_KEY, JSON.stringify(fullMontyStore)); }
+  catch(e){}
+}
+
+function queueSave(){
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(saveStore, 250);
+}
+
+function loadStore(){
+  try{
+    const raw = localStorage.getItem(LS_KEY);
+    if(raw){ Object.assign(fullMontyStore, JSON.parse(raw)); }
+  }catch(e){}
+}
+
+loadStore();
+
+(function migrateOld(){
+  const s = fullMontyStore;
+
+  if(Array.isArray(s.cashLike)){
+    if(!s.liquidity) s.liquidity = { currentAccount:0, cashSavings:0, moneyMarket:0, bond100:0, otherInstant:0 };
+    s.cashLike.forEach(r => { const v = +r.value || 0; s.liquidity.otherInstant += v; });
+    delete s.cashLike; queueSave();
+  }
+  if(Array.isArray(s.investments)){
+    const sum = s.investments.reduce((a,r)=>a+(+r.value||0),0);
+    s.investments = { etfIndexFunds: sum, mixedEquityFunds:0, brokerageCash:0, otherInvestments:0 };
+    queueSave();
+  }
+  if(Array.isArray(s.homes)){
+    const total = s.homes.reduce((a,r)=>a+(+r.value||0),0);
+    s.homes = { familyHome:{value:total,hasRent:false,rentAmount:0}, holidayHome:{value:0,hasRent:false,rentAmount:0} };
+    queueSave();
+  }
+})();
 
 function uuid() {
   if (crypto?.randomUUID) return crypto.randomUUID();
@@ -75,17 +145,20 @@ export function getStore() {
 
 export function setStore(patch) {
   Object.assign(fullMontyStore, patch);
+  queueSave();
 }
 
 export function pushRow(listKey, row) {
   if (!fullMontyStore[listKey]) fullMontyStore[listKey] = [];
   if (!row.id) row.id = uuid();
   fullMontyStore[listKey].push(row);
+  queueSave();
 }
 
 export function removeRow(listKey, id) {
   if (!Array.isArray(fullMontyStore[listKey])) return;
   fullMontyStore[listKey] = fullMontyStore[listKey].filter(r => r.id !== id);
+  queueSave();
 }
 
 // ───────────────────────────────────────────────────────────────
@@ -166,6 +239,7 @@ function makeListStepRenderer(
           const input = fieldEl.querySelector('input');
           input.addEventListener('input', () => {
             row[f.key] = numFromInput(input) || 0;
+            queueSave();
           });
         } else if (f.type === 'percent') {
           fieldEl = percentInput({ id, value: row[f.key] ?? '' });
@@ -174,13 +248,14 @@ function makeListStepRenderer(
             const v = clampPercent(numFromInput(input));
             input.value = v ?? '';
             row[f.key] = v ?? 0;
+            queueSave();
           });
         } else {
           fieldEl = document.createElement('input');
           fieldEl.type = 'text';
           fieldEl.id = id;
           fieldEl.value = row[f.key] ?? '';
-          fieldEl.addEventListener('input', () => { row[f.key] = fieldEl.value; });
+          fieldEl.addEventListener('input', () => { row[f.key] = fieldEl.value; queueSave(); });
         }
 
         wrap.appendChild(formGroup(id, f.label, fieldEl));
@@ -193,6 +268,7 @@ function makeListStepRenderer(
       rm.addEventListener('click', () => {
         removeRow(listKey, row.id);
         list.removeChild(wrap);
+        queueSave();
       });
       wrap.appendChild(rm);
 
@@ -264,144 +340,126 @@ renderStepGoal.validate = () => {
 };
 // Step 5–9 renderers
 // Step 5 — Homes you live in / holiday places
-function renderStepHomes(container) {
-  container.innerHTML = '';
-
-  const form = document.createElement('div');
-  form.className = 'form';
-
-  const list = document.createElement('div');
-  list.className = 'list-wrap';
-
-  // paint existing rows
-  (fullMontyStore.homes || []).forEach(row => list.appendChild(makeHomeRow(row)));
-
-  // Add button
-  const add = document.createElement('button');
-  add.type = 'button';
-  add.className = 'btn-list-add';
-  add.textContent = 'Add home';
-  add.addEventListener('click', () => {
-    const r = { id: uuid(), name: '', value: 0, hasRent: false, rentAmount: 0 };
-    pushRow('homes', r);
-    const el = makeHomeRow(r);
-    list.appendChild(el);
-    setTimeout(() => el.scrollIntoView({ block:'nearest', behavior:'smooth' }), 0);
+function renderStepHomes(container){
+  const s = getStore();
+  const H = s.homes || (s.homes = {
+    familyHome: { value: 0, hasRent: false, rentAmount: 0 },
+    holidayHome: { value: 0, hasRent: false, rentAmount: 0 }
   });
 
-  // Hint
+  container.innerHTML = '';
+  const form = document.createElement('div'); form.className = 'form';
+
+  form.appendChild(homeBlock('Family home', 'familyHome'));
+  form.appendChild(homeBlock('Holiday home', 'holidayHome'));
+
   const help = document.createElement('div');
   help.className = 'help';
-  help.textContent = 'Family home or holiday home you use yourself.';
+  help.textContent = 'Enter estimated current values. If a property generates rent (e.g., room letting/holiday-let), toggle and enter yearly rent.';
+  form.appendChild(help);
 
-  form.append(list, add, help);
   container.appendChild(form);
 
-  // ——— row builder ———
-  function makeHomeRow(row) {
+  function homeBlock(label, key){
     const wrap = document.createElement('div');
     wrap.className = 'asset-row form-group card-like';
 
-    // Name
-    const nameInp = document.createElement('input');
-    nameInp.type = 'text';
-    nameInp.id = `home-name-${row.id}`;
-    nameInp.value = row.name ?? '';
-    nameInp.placeholder = 'e.g., Family home';
-    nameInp.addEventListener('input', () => { row.name = nameInp.value; });
+    const nameLabel = document.createElement('label');
+    nameLabel.textContent = label; nameLabel.style.fontWeight = '700';
+    nameLabel.style.marginBottom = '.4rem';
+    wrap.appendChild(nameLabel);
 
-    wrap.appendChild(formGroup(nameInp.id, 'Name', nameInp));
+    const valWrap = currencyInput({ id: `${key}-value`, value: H[key].value || '' });
+    const valEl = valWrap.querySelector('input');
+    valEl.addEventListener('input', () => { H[key].value = Math.max(0, numFromInput(valEl) ?? 0); queueSave(); });
+    wrap.appendChild(formGroup(`${key}-value`, 'Value (€)', valWrap));
 
-    // Value €
-    const valueWrap = currencyInput({ id: `home-val-${row.id}`, value: row.value ?? '' });
-    const valueEl = valueWrap.querySelector('input');
-    valueEl.addEventListener('input', () => { row.value = Math.max(0, numFromInput(valueEl) ?? 0); });
+    const toggleId = `${key}-hasRent`;
+    const ctrl = document.createElement('div'); ctrl.className = 'control control-switch';
+    const cb = document.createElement('input'); cb.type='checkbox'; cb.id = toggleId; cb.checked = !!H[key].hasRent;
+    const lab = document.createElement('label'); lab.htmlFor = toggleId; lab.textContent = 'This property generates rental income';
+    ctrl.append(cb, lab); wrap.appendChild(ctrl);
 
-    wrap.appendChild(formGroup(`home-val-${row.id}`, 'Value', valueWrap));
-
-    // Rent toggle + conditional rent amount
-    const toggleId = `home-hasRent-${row.id}`;
-    const toggleGrp = document.createElement('div');
-    toggleGrp.className = 'control control-switch';
-    const toggle = document.createElement('input');
-    toggle.type = 'checkbox';
-    toggle.id = toggleId;
-    toggle.checked = !!row.hasRent;
-    const toggleLab = document.createElement('label');
-    toggleLab.htmlFor = toggleId;
-    toggleLab.textContent = 'I get rental income from this property';
-    toggleGrp.append(toggle, toggleLab);
-
-    // Rent amount input (hidden unless checked)
-    const rentWrap = currencyInput({ id: `home-rent-${row.id}`, value: row.rentAmount ?? '' });
+    const rentGrpWrap = document.createElement('div');
+    const rentWrap = currencyInput({ id: `${key}-rent`, value: H[key].rentAmount || '' });
     const rentEl = rentWrap.querySelector('input');
-    rentEl.addEventListener('input', () => { row.rentAmount = Math.max(0, numFromInput(rentEl) ?? 0); });
+    rentEl.addEventListener('input', () => { H[key].rentAmount = Math.max(0, numFromInput(rentEl) ?? 0); queueSave(); });
 
-    const rentFormGrp = formGroup(`home-rent-${row.id}`, 'Rental income (yearly)', rentWrap);
-    rentFormGrp.classList.add('condensed');
-    rentFormGrp.style.display = toggle.checked ? '' : 'none';
-
-    toggle.addEventListener('change', () => {
-      row.hasRent = toggle.checked;
-      if (!row.hasRent) row.rentAmount = 0;
-      rentFormGrp.style.display = row.hasRent ? '' : 'none';
+    rentGrpWrap.appendChild(formGroup(`${key}-rent`, 'Rental income (yearly)', rentWrap));
+    rentGrpWrap.style.display = cb.checked ? '' : 'none';
+    cb.addEventListener('change', () => {
+      H[key].hasRent = cb.checked;
+      if (!cb.checked) { H[key].rentAmount = 0; rentEl.value = ''; }
+      rentGrpWrap.style.display = cb.checked ? '' : 'none';
+      queueSave();
     });
 
-    wrap.append(toggleGrp, rentFormGrp);
-
-    // Remove row
-    const rm = document.createElement('button');
-    rm.type = 'button';
-    rm.className = 'btn-row-remove';
-    rm.textContent = 'Remove';
-    rm.addEventListener('click', () => {
-      removeRow('homes', row.id);
-      wrap.remove();
-    });
-    wrap.appendChild(rm);
-
+    wrap.appendChild(rentGrpWrap);
     return wrap;
   }
 }
 renderStepHomes.validate = () => {
-  const arr = getStore().homes || [];
-  // keep only positive-value homes; if hasRent false, force rentAmount to 0
-  arr.forEach(r => {
-    r.value = Math.max(0, +r.value || 0);
-    if (!r.hasRent) r.rentAmount = 0;
-    else r.rentAmount = Math.max(0, +r.rentAmount || 0);
+  const H = getStore().homes;
+  ['familyHome','holidayHome'].forEach(k => {
+    H[k].value = Math.max(0, +H[k].value || 0);
+    H[k].rentAmount = H[k].hasRent ? Math.max(0, +H[k].rentAmount || 0) : 0;
   });
-  setStore({ homes: arr.filter(r => r.value > 0) });
+  setStore({ homes: H });
   return { ok: true };
 };
 
-const renderStepCash = makeListStepRenderer('cashLike', {
-  addLabel: 'Add item',
-  hint: 'Cash on deposit, savings accounts, money market funds, 100% bond portfolio.',
-  fields: [
-    { key: 'name', label: 'Name', type: 'text' },
-    { key: 'value', label: 'Value', type: 'currency', default: 0 }
-  ]
-});
-renderStepCash.validate = () => {
-  const arr = getStore().cashLike || [];
-  setStore({ cashLike: arr.filter(r => (r.value || 0) > 0) });
-  return { ok: true };
-};
+function renderStepCash(container){
+  const s = getStore();
+  const L = s.liquidity || (s.liquidity = { currentAccount:0, cashSavings:0, moneyMarket:0, bond100:0, otherInstant:0 });
 
-const renderStepInvest = makeListStepRenderer('investments', {
-  addLabel: 'Add investment',
-  hint: 'Investment accounts/funds (mixed asset or equity funds). Exclude pensions (we captured those earlier).',
-  fields: [
-    { key: 'name', label: 'Name', type: 'text' },
-    { key: 'value', label: 'Value', type: 'currency', default: 0 }
-  ]
-});
-renderStepInvest.validate = () => {
-  const arr = getStore().investments || [];
-  setStore({ investments: arr.filter(r => (r.value || 0) > 0) });
-  return { ok: true };
-};
+  container.innerHTML = '';
+  const form = document.createElement('div'); form.className = 'form';
+
+  form.appendChild(currencyRow('Cash in current account (€)', 'currentAccount'));
+  form.appendChild(currencyRow('Cash savings (€)', 'cashSavings'));
+  form.appendChild(currencyRow('Money‑market funds (€)', 'moneyMarket'));
+  form.appendChild(currencyRow('100% bond portfolios (€)', 'bond100'));
+  form.appendChild(currencyRow('Other instantly‑available assets (€)', 'otherInstant'));
+
+  const help = document.createElement('div'); help.className='help';
+  help.textContent = 'Instant or near‑instant access assets.';
+  form.appendChild(help);
+
+  container.appendChild(form);
+
+  function currencyRow(label, key){
+    const w = currencyInput({ id:`liq-${key}`, value: L[key] || '' });
+    w.querySelector('input').addEventListener('input', e => { L[key] = Math.max(0, numFromInput(e.target) ?? 0); queueSave(); });
+    return formGroup(`liq-${key}`, label, w);
+  }
+}
+renderStepCash.validate = () => { setStore({ liquidity: getStore().liquidity }); return { ok:true }; };
+
+function renderStepInvest(container){
+  const s = getStore();
+  const I = s.investments || (s.investments = { etfIndexFunds:0, mixedEquityFunds:0, brokerageCash:0, otherInvestments:0 });
+
+  container.innerHTML = '';
+  const form = document.createElement('div'); form.className='form';
+
+  form.appendChild(currencyRow('ETF / Index funds (€)', 'etfIndexFunds'));
+  form.appendChild(currencyRow('Mixed / equity funds (non‑pension) (€)', 'mixedEquityFunds'));
+  form.appendChild(currencyRow('Brokerage cash (€)', 'brokerageCash'));
+  form.appendChild(currencyRow('Other investments (€)', 'otherInvestments'));
+
+  const help = document.createElement('div'); help.className='help';
+  help.textContent = 'Exclude pensions (we captured those earlier).';
+  form.appendChild(help);
+
+  container.appendChild(form);
+
+  function currencyRow(label, key){
+    const w = currencyInput({ id:`inv-${key}`, value: I[key] || '' });
+    w.querySelector('input').addEventListener('input', e => { I[key] = Math.max(0, numFromInput(e.target) ?? 0); queueSave(); });
+    return formGroup(`inv-${key}`, label, w);
+  }
+}
+renderStepInvest.validate = () => { setStore({ investments: getStore().investments }); return { ok:true }; };
 
 const renderStepRentProps = makeListStepRenderer('rentProps', {
   addLabel: 'Add property',
@@ -419,20 +477,65 @@ renderStepRentProps.validate = () => {
   return { ok: true };
 };
 
-const renderStepLiabilities = makeListStepRenderer('liabilities', {
-  addLabel: 'Add liability',
-  hint: 'Loans, credit cards, other debts.',
-  valueKey: 'balance',
-  fields: [
-    { key: 'name', label: 'Name', type: 'text' },
-    { key: 'balance', label: 'Balance', type: 'currency', default: 0 },
-    { key: 'rate', label: 'Rate', type: 'percent' }
-  ]
-});
+function renderStepLiabilities(container){
+  const s = getStore();
+  const D = s.liabilities || (s.liabilities = {
+    mortgageHome:{balance:0,rate:0}, mortgageRental:{balance:0,rate:0},
+    creditCard:{balance:0,rate:0}, personalLoan:{balance:0,rate:0},
+    carFinance:{balance:0,rate:0}, studentLoan:{balance:0,rate:0},
+    taxOwed:{balance:0,rate:0}, otherDebt:{balance:0,rate:0}
+  });
+
+  container.innerHTML = '';
+  const form = document.createElement('div'); form.className='form';
+
+  const rows = [
+    ['Mortgage (home)', 'mortgageHome'],
+    ['Mortgage (rental)', 'mortgageRental'],
+    ['Credit cards', 'creditCard'],
+    ['Personal loans', 'personalLoan'],
+    ['Car finance', 'carFinance'],
+    ['Student loan', 'studentLoan'],
+    ['Tax owed', 'taxOwed'],
+    ['Other debt', 'otherDebt']
+  ];
+
+  rows.forEach(([label, key]) => form.appendChild(debtRow(label, key)));
+
+  const help = document.createElement('div'); help.className='help';
+  help.textContent = 'Enter balances. Interest rate is optional; add it if you know it.';
+  form.appendChild(help);
+
+  container.appendChild(form);
+
+  function debtRow(label, key){
+    const grp = document.createElement('div'); grp.className='form-group card-like';
+
+    const title = document.createElement('div'); title.textContent = label;
+    title.style.fontWeight='700'; title.style.marginBottom='.35rem';
+    grp.appendChild(title);
+
+    const balWrap = currencyInput({ id:`debt-${key}-bal`, value: D[key].balance || '' });
+    const balEl = balWrap.querySelector('input');
+    balEl.addEventListener('input', e => { D[key].balance = Math.max(0, numFromInput(e.target) ?? 0); queueSave(); });
+    grp.appendChild(formGroup(`debt-${key}-bal`, 'Balance (€)', balWrap));
+
+    const rateWrap = percentInput({ id:`debt-${key}-rate`, value: D[key].rate || '' });
+    const rateEl = rateWrap.querySelector('input');
+    rateEl.addEventListener('input', e => { D[key].rate = clampPercent(numFromInput(e.target) ?? 0); queueSave(); });
+    grp.appendChild(formGroup(`debt-${key}-rate`, 'Interest rate (%)', rateWrap));
+
+    return grp;
+  }
+}
 renderStepLiabilities.validate = () => {
-  const arr = getStore().liabilities || [];
-  setStore({ liabilities: arr.filter(r => (r.balance || 0) > 0) });
-  return { ok: true };
+  const D = getStore().liabilities;
+  Object.values(D).forEach(d => {
+    d.balance = Math.max(0, +d.balance || 0);
+    d.rate = clampPercent(+d.rate || 0);
+  });
+  setStore({ liabilities: D });
+  return { ok:true };
 };
 
 // ───────────────────────────────────────────────────────────────
@@ -446,6 +549,7 @@ const btnNext = q('fmNext');
 const dots = q('fmDots');
 const progEl = q('fmProgress');
 const progFill = q('fmProgressFill');
+const titleEl = q('fmTitle');
 
 let cur = 0;
 
@@ -460,7 +564,7 @@ function focusFirst() {
 const steps = [
   {
     id: 'household',
-    title: 'Household',
+    title: 'About you',
     render(cont) {
       cont.innerHTML = '';
       const form = document.createElement('div');
@@ -523,7 +627,7 @@ const steps = [
 
   {
     id: 'income',
-    title: 'Income today',
+    title: 'Your income today',
     render(cont) {
       cont.innerHTML = '';
       const form = document.createElement('div');
@@ -555,14 +659,14 @@ const steps = [
 
   {
     id: 'goal',
-    title: 'Retirement goal (percent-only)',
+    title: 'Retirement income target',
     render: renderStepGoal,
     validate: renderStepGoal.validate
   },
 
   {
     id: 'pensions',
-    title: 'Pensions (DC/DB/State)',
+    title: 'Pensions & entitlements',
     render(cont) {
       cont.innerHTML = '';
       const form = document.createElement('div');
@@ -652,21 +756,21 @@ const steps = [
 
   {
     id: 'homes',
-    title: 'Homes you live in / holiday places',
+    title: 'Homes / holiday homes',
     render: renderStepHomes,
     validate: renderStepHomes.validate
   },
 
   {
     id: 'cash',
-    title: 'Cash & easy-access savings (incl. 100% bonds)',
+    title: 'Cash & easy-access savings',
     render: renderStepCash,
     validate: renderStepCash.validate
   },
 
   {
     id: 'investments',
-    title: 'Investments (funds/accounts, not pensions)',
+    title: 'Investments (non-pension)',
     render: renderStepInvest,
     validate: renderStepInvest.validate
   },
@@ -700,10 +804,8 @@ function render() {
   const total = steps.length;
   progEl.textContent = `Step ${cur + 1} of ${total}`;
   progFill.style.width = ((cur + 1) / total * 100) + '%';
+  titleEl.textContent = step.title;
   container.innerHTML = '';
-  const h = document.createElement('h3');
-  h.textContent = step.title;
-  container.appendChild(h);
   step.render(container);
   dots.innerHTML = steps.map((_, i) => `<button class="wizDot${i === cur ? ' active' : ''}" data-idx="${i}"></button>`).join('');
   dots.querySelectorAll('button').forEach((b, i) => {
@@ -753,37 +855,64 @@ addKeyboardNav(modal, { back, next, close: () => modal.classList.add('hidden'), 
 // Run handler & auto classification
 // ----------------------------------------------------------------
 
-function getResolvedTotalRent() {
+function getResolvedTotalRent(){
   const s = getStore();
 
-  // Sum per-property rents from rental properties
+  const homesRent = ['familyHome','holidayHome'].reduce((sum,k)=>{
+    const h = s.homes?.[k]; if(!h) return sum;
+    return sum + (h.hasRent ? ( +h.rentAmount || 0 ) : 0);
+  }, 0);
+
   const rentPropsSum = (s.rentProps || [])
     .map(p => +p.grossRent || 0)
     .filter(v => v > 0)
-    .reduce((a, b) => a + b, 0);
+    .reduce((a,b)=>a+b, 0);
 
-  // Sum optional rents on homes
-  const homesRentSum = (s.homes || [])
-    .filter(h => h.hasRent)
-    .map(h => +h.rentAmount || 0)
-    .filter(v => v > 0)
-    .reduce((a, b) => a + b, 0);
-
-  return rentPropsSum + homesRentSum;
+  return homesRent + rentPropsSum;
 }
 
-function buildBalanceSheet() {
-  const lifestyle = fullMontyStore.homes.filter(r => r.value > 0);
-  const liquidity = fullMontyStore.cashLike.filter(r => r.value > 0);
-  const longevity = fullMontyStore.investments.filter(r => r.value > 0);
-  const legacy = [
-    ...fullMontyStore.rentProps.filter(r => r.value > 0).map(({ name, value }) => ({ name, value })),
-    ...fullMontyStore.valuables.filter(r => r.value > 0)
-  ];
+function buildBalanceSheet(){
+  const H = fullMontyStore.homes;
+  const L = fullMontyStore.liquidity;
+  const I = fullMontyStore.investments;
+  const D = fullMontyStore.liabilities;
+
+  const lifestyle = [
+    { name:'Family home', value:H.familyHome.value },
+    { name:'Holiday home', value:H.holidayHome.value }
+  ].filter(r => r.value > 0);
+
+  const liquidity = [
+    { name:'Cash in current account', value:L.currentAccount },
+    { name:'Cash savings', value:L.cashSavings },
+    { name:'Money-market funds', value:L.moneyMarket },
+    { name:'100% bond portfolios', value:L.bond100 },
+    { name:'Other instantly-available assets', value:L.otherInstant }
+  ].filter(r => r.value > 0);
+
+  const longevity = [
+    { name:'ETF / Index funds', value:I.etfIndexFunds },
+    { name:'Mixed / equity funds', value:I.mixedEquityFunds },
+    { name:'Brokerage cash', value:I.brokerageCash },
+    { name:'Other investments', value:I.otherInvestments }
+  ].filter(r => r.value > 0);
+
+  const legacy = (fullMontyStore.rentProps || [])
+    .filter(r => r.value > 0)
+    .map(({ name, value }) => ({ name, value }));
+
   const liabs = [
-    ...fullMontyStore.liabilities.filter(r => r.balance > 0).map(({ name, balance }) => ({ name, balance })),
-    ...fullMontyStore.rentProps.filter(r => r.mortgageBalance > 0).map(({ name, mortgageBalance }) => ({ name: name + ' mortgage', balance: mortgageBalance }))
-  ];
+    { name:'Mortgage (home)', balance:D.mortgageHome.balance },
+    { name:'Mortgage (rental)', balance:D.mortgageRental.balance },
+    { name:'Credit cards', balance:D.creditCard.balance },
+    { name:'Personal loans', balance:D.personalLoan.balance },
+    { name:'Car finance', balance:D.carFinance.balance },
+    { name:'Student loan', balance:D.studentLoan.balance },
+    { name:'Tax owed', balance:D.taxOwed.balance },
+    { name:'Other debt', balance:D.otherDebt.balance },
+    ...(fullMontyStore.rentProps || []).filter(r => r.mortgageBalance > 0).map(({name,mortgageBalance}) => ({ name: name + ' mortgage', balance: mortgageBalance }))
+  ].filter(r => r.balance > 0);
+
   return { lifestyle, liquidity, longevity, legacy, liabilities: liabs };
 }
 

--- a/ui-inputs.js
+++ b/ui-inputs.js
@@ -1,19 +1,29 @@
 // ui-inputs.js
-export function currencyInput({ id, value = '', placeholder = '' } = {}){
+export function attachZeroClear(input){
+  if(!input) return;
+  input.addEventListener('focus', () => { if(input.value === '0') input.value = ''; });
+  input.addEventListener('blur', () => { if(input.value === '') input.value = '0'; });
+  return input;
+}
+
+export function currencyInput({ id, value = '', placeholder = '0' } = {}){
   const wrap = document.createElement('div'); wrap.className = 'input-wrap prefix';
   const unit = document.createElement('span'); unit.className='unit'; unit.textContent='€';
   const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
   inp.inputMode='decimal'; inp.placeholder=placeholder;
   if(value !== '' && value != null) inp.value=value;
+  attachZeroClear(inp);
   wrap.append(unit, inp);
   return wrap;
 }
-export function percentInput({ id, value = '', placeholder = '' } = {}){
+
+export function percentInput({ id, value = '', placeholder = '0' } = {}){
   const wrap = document.createElement('div'); wrap.className = 'input-wrap suffix';
   const unit = document.createElement('span'); unit.className='unit'; unit.textContent='%';
   const inp = document.createElement('input'); inp.type='number'; inp.id=id || (globalThis.crypto?.randomUUID?.() || ('id-'+Math.random().toString(36).slice(2)));
   inp.inputMode='decimal'; inp.min='0'; inp.max='100'; inp.step='0.1'; inp.placeholder=placeholder;
   if(value !== '' && value != null) inp.value=value;
+  attachZeroClear(inp);
   wrap.append(inp, unit);
   return wrap;
 }


### PR DESCRIPTION
## Summary
- Replace ad-hoc asset/debt arrays with structured buckets and auto-saving localStorage
- Introduce grouped input steps for homes, liquidity, investments, rental properties, and liabilities
- Add card-like styling and switch polish; auto-clear zero placeholders for currency and percent inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bad594dc83338505b939991618b3