### PR TITLE
Refactor Full Monty asset and debt inputs

### DIFF
--- a/styles/inputs.css
+++ b/styles/inputs.css
@@ -91,3 +91,16 @@ button.wizDot.active, button.wizDot:focus-visible{ background:#c000ff; outline:n
   transform:scale(1.03);
   box-shadow:0 0 22px rgba(0,255,136,.8);
 }
+
+.card-like{
+  background:#353535;
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:12px;
+  padding:.9rem;
+}
+.card-like .form-group + .form-group{ margin-top:.8rem; }
+
+.control.control-switch{
+  display:flex; align-items:center; gap:.6rem; margin:.3rem 0 .3rem;
+}
+.control.control-switch input[type="checkbox"]{ accent-color:#00aaff; }


### PR DESCRIPTION
## Summary
- Replace array-based asset and debt storage with structured buckets for homes, liquidity, investments, and liabilities
- Add grouped input renderers for homes, cash, investments and debts; keep list for rental properties
- Migrate old localStorage data and compute totals with new helpers
- Polish Full Monty CSS with card-like groups and switch styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898be0fb37083339955c747dade3880