### PR TITLE
Clarify mortgage balance inputs across property forms

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -283,14 +283,14 @@ function makeListStepRenderer(
         let fieldEl;
 
         if (f.type === 'currency') {
-          fieldEl = currencyInput({ id, value: row[f.key] ?? '' });
+          fieldEl = currencyInput({ id, value: row[f.key] ?? '', placeholder: f.placeholder });
           const input = fieldEl.querySelector('input');
           input.addEventListener('input', () => {
             row[f.key] = numFromInput(input) || 0;
             queueSave();
           });
         } else if (f.type === 'percent') {
-          fieldEl = percentInput({ id, value: row[f.key] ?? '' });
+          fieldEl = percentInput({ id, value: row[f.key] ?? '', placeholder: f.placeholder });
           const input = fieldEl.querySelector('input');
           input.addEventListener('input', () => {
             const v = clampPercent(numFromInput(input));
@@ -303,10 +303,18 @@ function makeListStepRenderer(
           fieldEl.type = 'text';
           fieldEl.id = id;
           fieldEl.value = row[f.key] ?? '';
+          if (f.placeholder) fieldEl.placeholder = f.placeholder;
           fieldEl.addEventListener('input', () => { row[f.key] = fieldEl.value; queueSave(); });
         }
 
-        wrap.appendChild(formGroup(id, f.label, fieldEl));
+        const group = formGroup(id, f.label, fieldEl);
+        if (f.help) {
+          const h = document.createElement('div');
+          h.className = 'help';
+          h.textContent = f.help;
+          group.appendChild(h);
+        }
+        wrap.appendChild(group);
       });
 
       const rm = document.createElement('button');
@@ -489,9 +497,13 @@ function renderStepHomes(container){
     });
     wrap.appendChild(formGroup(`${key}-value`, 'Value (€)', valWrap));
 
-    const mortWrap = currencyInput({ id: `${key}-mortgage`, value: obj.mortgage || '' });
+    const mortWrap = currencyInput({ id: `${key}-mortgage`, value: obj.mortgage || '', placeholder: 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).' });
     const mortEl = mortWrap.querySelector('input');
-    const mortGroup = formGroup(`${key}-mortgage`, 'Mortgage (€)', mortWrap);
+    const mortGroup = formGroup(`${key}-mortgage`, 'Remaining mortgage balance (€)', mortWrap);
+    const help = document.createElement('div');
+    help.className = 'help';
+    help.textContent = 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).';
+    mortGroup.appendChild(help);
     const warn = document.createElement('div');
     warn.textContent = 'Mortgage exceeds value.';
     warn.style.color = '#ffb74d';
@@ -557,9 +569,13 @@ function renderStepHomes(container){
     });
     wrap.appendChild(formGroup(`hh-${hh.id}-value`, 'Value (€)', valWrap));
 
-    const mortWrap = currencyInput({ id: `hh-${hh.id}-mortgage`, value: hh.mortgage || '' });
+    const mortWrap = currencyInput({ id: `hh-${hh.id}-mortgage`, value: hh.mortgage || '', placeholder: 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).' });
     const mortEl = mortWrap.querySelector('input');
-    const mortGroup = formGroup(`hh-${hh.id}-mortgage`, 'Mortgage (€)', mortWrap);
+    const mortGroup = formGroup(`hh-${hh.id}-mortgage`, 'Remaining mortgage balance (€)', mortWrap);
+    const help = document.createElement('div');
+    help.className = 'help';
+    help.textContent = 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).';
+    mortGroup.appendChild(help);
     const warn = document.createElement('div');
     warn.textContent = 'Mortgage exceeds value.';
     warn.style.color = '#ffb74d';
@@ -716,11 +732,11 @@ renderStepInvest.validate = () => { setStore({ investments: getStore().investmen
 
 const renderStepRentProps = makeListStepRenderer('rentProps', {
   addLabel: 'Add property',
-  hint: 'Properties you rent out (include mortgage balance and gross rent).',
+  hint: 'Properties you rent out (include the remaining mortgage balance—i.e., the amount you still owe today—and gross rent).',
   fields: [
     { key: 'name', label: 'Name', type: 'text' },
     { key: 'value', label: 'Value', type: 'currency', default: 0 },
-    { key: 'mortgageBalance', label: 'Mortgage balance', type: 'currency', default: 0 },
+    { key: 'mortgageBalance', label: 'Remaining mortgage balance (€)', type: 'currency', default: 0, placeholder: 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).', help: 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).' },
     { key: 'grossRent', label: 'Gross rent', type: 'currency' }
   ]
 });
@@ -762,10 +778,17 @@ function renderStepLiabilities(container){
     title.style.fontWeight='700'; title.style.marginBottom='.35rem';
     grp.appendChild(title);
 
-    const balWrap = currencyInput({ id:`debt-${key}-bal`, value: D[key].balance || '' });
+    const balWrap = currencyInput({ id:`debt-${key}-bal`, value: D[key].balance || '', placeholder: label === 'Mortgage (rental)' ? 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).' : '' });
     const balEl = balWrap.querySelector('input');
     balEl.addEventListener('input', e => { D[key].balance = Math.max(0, numFromInput(e.target) ?? 0); queueSave(); });
-    grp.appendChild(formGroup(`debt-${key}-bal`, 'Balance (€)', balWrap));
+    const balGroup = formGroup(`debt-${key}-bal`, label === 'Mortgage (rental)' ? 'Remaining mortgage balance (€)' : 'Balance (€)', balWrap);
+    if (label === 'Mortgage (rental)') {
+      const h = document.createElement('div');
+      h.className = 'help';
+      h.textContent = 'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).';
+      balGroup.appendChild(h);
+    }
+    grp.appendChild(balGroup);
 
     const rateWrap = percentInput({ id:`debt-${key}-rate`, value: D[key].rate || '' });
     const rateEl = rateWrap.querySelector('input');

--- a/personalBalanceSheet.js
+++ b/personalBalanceSheet.js
@@ -96,7 +96,7 @@ const wizardSteps = [
     fields:[
       {id:'ownsHome', label:'Do you own your primary home?', type:'select', options:['Yes','No']},
       {id:'homeValue', label:'Market value (€)', type:'number', showIf:d=>d.ownsHome==='Yes'},
-      {id:'homeMortgage', label:'Outstanding mortgage (€)', type:'number', optional:true, showIf:d=>d.ownsHome==='Yes'},
+      {id:'homeMortgage', label:'Remaining mortgage balance (€)', placeholder:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).', type:'number', optional:true, showIf:d=>d.ownsHome==='Yes', help:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).'},
       {id:'rentRoom', label:'Renting a room?', type:'select', options:['No','Yes occasional','Yes regular'], showIf:d=>d.ownsHome==='Yes'},
       {id:'optionalNotice', type:'note', text:'The following details are optional.', showIf:d=>d.ownsHome==='Yes'},
       {id:'rentalIncome', label:'Annual rental income (€ gross)', type:'number', optional:true, showIf:d=>d.ownsHome==='Yes' && d.rentRoom && d.rentRoom!=='No'},
@@ -112,7 +112,7 @@ const wizardSteps = [
     fields:[
       {id:'nick', label:'Nickname / location', type:'text'},
       {id:'value', label:'Market value (€)', type:'number'},
-      {id:'mortgage', label:'Mortgage (€)', type:'number', optional:true},
+      {id:'mortgage', label:'Remaining mortgage balance (€)', placeholder:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).', type:'number', optional:true, help:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).'},
       {id:'rented', label:'Is it rented?', type:'select', options:['No','Yes']},
       {id:'optionalNotice', type:'note', text:'The following details are optional.'},
       {id:'rentalIncome', label:'Annual rental income (€ gross)', type:'number', optional:true, showIf:d=>d.rented==='Yes'},
@@ -165,7 +165,7 @@ const wizardSteps = [
     fields:[
       {id:'nick', label:'Nickname', type:'text'},
       {id:'value', label:'Market value (€)', type:'number'},
-      {id:'mortgage', label:'Mortgage (€)', type:'number', optional:true},
+      {id:'mortgage', label:'Remaining mortgage balance (€)', placeholder:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).', type:'number', optional:true, help:'Please enter the remaining mortgage balance on this property (i.e., the amount you still owe today, not the original loan amount).'},
       {id:'rented', label:'Is it rented?', type:'select', options:['No','Yes']},
       {id:'optionalNotice', type:'note', text:'The following details are optional.'},
       {id:'rentalIncome', label:'Annual rental income (€ gross)', type:'number', optional:true, showIf:d=>d.rented==='Yes'},
@@ -235,23 +235,23 @@ function createInput(field,id,value,labelTxt){
   }
   if(field.type==='number'){
     if(labelTxt && labelTxt.includes('%')){
-      const wrap=percentInput({id,value});
+      const wrap=percentInput({id,value,placeholder:field.placeholder});
       const inp=wrap.querySelector('input');
       if(!field.optional) inp.required=true;
       inp.addEventListener('input',e=>{const v=clampPercent(numFromInput(e.target)); e.target.value = v ?? '';});
       return wrap;
     }
     if(labelTxt && labelTxt.includes('€')){
-      const wrap=currencyInput({id,value});
+      const wrap=currencyInput({id,value,placeholder:field.placeholder});
       const inp=wrap.querySelector('input');
       if(!field.optional) inp.required=true;
       return wrap;
     }
-    const inp=el('input',{id,type:'number',value:value||''});
+    const inp=el('input',{id,type:'number',value:value||'',placeholder:field.placeholder||''});
     if(!field.optional) inp.required=true;
     return inp;
   }
-  const inp=el('input',{id,type:'text',value:value||''});
+  const inp=el('input',{id,type:'text',value:value||'',placeholder:field.placeholder||''});
   if(!field.optional) inp.required=true;
   return inp;
 }


### PR DESCRIPTION
## Summary
- Clarify that mortgage inputs require remaining balance across personal balance sheet and Full Monty wizards
- Support placeholders and help text in dynamic property forms
- Update rental property liabilities to use explicit remaining mortgage wording

## Testing
- `node --check personalBalanceSheet.js`
- `node --check fullMontyWizard.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb40133c8333858609741db49e0b