### PR TITLE
Redesign Learn section with portrait video cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,66 +151,6 @@
     @media (max-width:480px){.bubble{width:100%;max-width:280px;aspect-ratio:1}}
     /* Accessibility focus */
     a:focus-visible,.btn-primary:focus-visible{outline:2px solid var(--accentA);outline-offset:3px;box-shadow:0 0 0 3px rgba(0,255,136,.25)}
-
-    /* Small CTA thumbnail container */
-    .hero-video-cta{
-      margin-top: .6rem;
-    }
-
-    /* ——— Thumbnail Button ——— */
-    .yt-thumb{
-      position: relative;
-      width: 100%;
-      max-width: 220px;
-      aspect-ratio: 9 / 16;
-      border: 1px solid rgba(255,255,255,.14);
-      border-radius: 14px;
-      background: #000; /* JS sets poster */
-      background-size: cover;
-      background-position: center;
-      overflow: hidden;
-      cursor: pointer;
-      transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
-    }
-    .yt-thumb::after{
-      content:""; position:absolute; inset:0;
-      background: linear-gradient(to top, rgba(0,0,0,.55), rgba(0,0,0,.1));
-      pointer-events:none;
-    }
-    .yt-thumb:hover,
-    .yt-thumb:focus-visible{
-      transform: translateY(-3px);
-      border-color: var(--pmag2);
-      box-shadow: 0 0 20px rgba(127,0,255,.6);
-      outline: 2px solid var(--pmag2);
-      outline-offset: 2px;
-    }
-    .yt-thumb__play{
-      position: absolute; inset:auto auto 10px 10px;
-      display: grid; place-items:center;
-      width: 52px; height: 52px; border-radius: 50%;
-      background: rgba(0,0,0,.6);
-      border: 2px solid var(--pmag2);
-      color:#fff; font-size: 22px; line-height: 1;
-      box-shadow: 0 0 20px rgba(127,0,255,.45);
-    }
-    .yt-thumb__play::before{
-      content:""; position:absolute; inset:-6px;
-      border-radius:50%; border: 2px solid rgba(127,0,255,.4);
-      animation: pulse 1.8s ease-in-out infinite;
-    }
-    @keyframes pulse{
-      0%,100%{ transform: scale(1); opacity: .6 }
-      50%   { transform: scale(1.08); opacity: .2 }
-    }
-    .yt-thumb__badge{
-      position: absolute; top: 8px; left: 8px;
-      font-size: 11px; color:#fff;
-      background: rgba(0,0,0,.55);
-      padding: 5px 8px; border-radius: 999px;
-      border: 1px solid rgba(255,255,255,.12);
-    }
-
     /* ——— Modal Base ——— */
     .modal[hidden]{ display:none !important; }
     .modal{
@@ -293,92 +233,104 @@
     .modal__body{ padding-bottom: env(safe-area-inset-bottom, 12px); }
     .modal__video{ max-height: none; }
     }
+/* ——— Learn section heading ——— */
+.learn{ margin: clamp(16px, 4vw, 28px) 0; }
+.learn__heading{
+  margin: 0 0 10px;
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.4rem, 2.6vw, 1.8rem);
+  color: var(--gold);
+}
 
-    /* Learn row layout */
-    .learn{
-      margin: clamp(12px, 3vw, 20px) 0;
-    }
-    .learn__grid{
-      display: grid;
-      gap: clamp(12px, 2.5vw, 18px);
-      grid-template-columns: 1fr;
-    }
-    @media (min-width: 780px){
-      .learn__grid{ grid-template-columns: repeat(3, 1fr); }
-    }
-    .learn-card{
-      background: var(--card);
-      border: 1px solid rgba(255,255,255,.08);
-      border-radius: 14px;
-      box-shadow: var(--shadow);
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-      min-height: 100%;
-    }
-    .learn-card__body{
-      padding: 12px 14px 14px;
-    }
-    .learn-card__title{
-      margin: 0 0 4px; font-size: 1.05rem; color: #fff;
-    }
-    .learn-card__text{
-      margin: 0; color: var(--muted); line-height: 1.45;
-    }
+/* ——— Grid layout ——— */
+.learn__grid{
+  display: grid;
+  gap: clamp(12px, 2.5vw, 18px);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 720px){ .learn__grid{ grid-template-columns: repeat(3, 1fr); }}
 
-    /* Video thumbnail styles */
-    .yt-thumb{
-      position: relative;
-      display: block;
-      width: 100%;
-      border: 0;
-      cursor: pointer;
-      background: #000; /* JS sets poster for real videos */
-      background-size: cover;
-      background-position: center;
-      overflow: hidden;
-    }
-    .yt-thumb--wide{ aspect-ratio: 16 / 9; }
-    .yt-thumb::after{
-      content:""; position:absolute; inset:0;
-      background: linear-gradient(to top, rgba(0,0,0,.45), rgba(0,0,0,.08));
-      pointer-events:none;
-    }
-    .yt-thumb__play{
-      position: absolute; inset:auto auto 10px 10px;
-      display: grid; place-items:center;
-      width: 48px; height: 48px; border-radius: 50%;
-      background: rgba(0,0,0,.6);
-      border: 2px solid var(--pmag2);
-      color:#fff; font-size: 20px; line-height: 1;
-      box-shadow: 0 0 18px rgba(127,0,255,.45);
-    }
-    .yt-thumb__play::before{
-      content:""; position:absolute; inset:-6px;
-      border-radius:50%; border: 2px solid rgba(127,0,255,.4);
-      animation: pulse 1.8s ease-in-out infinite;
-    }
-    @keyframes pulse{
-      0%,100%{ transform: scale(1); opacity: .6 }
-      50%   { transform: scale(1.08); opacity: .2 }
-    }
-    .yt-thumb__badge{
-      position: absolute; top: 8px; left: 8px;
-      font-size: 11px; color:#fff;
-      background: rgba(0,0,0,.55);
-      padding: 5px 8px; border-radius: 999px;
-      border: 1px solid rgba(255,255,255,.12);
-    }
+/* ——— Portrait card with full-media look ——— */
+.learn-card{
+  background: var(--card);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  min-height: 100%;
+}
+.learn-card--portrait .yt-thumb{
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 9 / 16;     /* portrait matches Shorts */
+  background: #000;         /* JS sets poster for live video */
+  background-size: cover;   /* fills the card */
+  background-position: center;
+  border: 0;
+  cursor: pointer;
+}
+.yt-thumb::after{
+  content:""; position:absolute; inset:0;
+  background: linear-gradient(to top, rgba(0,0,0,.45), rgba(0,0,0,.08));
+  pointer-events:none;
+}
+.yt-thumb:hover,
+.yt-thumb:focus-visible{
+  outline: 2px solid var(--pmag2);
+  outline-offset: -2px;
+  filter: brightness(1.03);
+  box-shadow: 0 0 16px rgba(127,0,255,.35) inset;
+}
 
-    /* Placeholder state */
-    .yt-thumb--placeholder{
-      background: linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.1));
-      cursor: default;
-    }
-    .yt-thumb--placeholder .yt-thumb__play{
-      opacity: 0.5;
-    }
-    .yt-thumb--placeholder::after{ background: none; }
+/* Play affordance */
+.yt-thumb__play{
+  position: absolute; inset:auto auto 10px 10px;
+  display: grid; place-items:center;
+  width: 48px; height: 48px; border-radius: 50%;
+  background: rgba(0,0,0,.6);
+  border: 2px solid var(--pmag2);
+  color:#fff; font-size: 20px; line-height: 1;
+  box-shadow: 0 0 18px rgba(127,0,255,.45);
+}
+.yt-thumb__play::before{
+  content:""; position:absolute; inset:-6px;
+  border-radius:50%; border: 2px solid rgba(127,0,255,.4);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+@keyframes pulse{
+  0%,100%{ transform: scale(1); opacity: .6 }
+  50%   { transform: scale(1.08); opacity: .2 }
+}
+.yt-thumb__badge{
+  position: absolute; top: 8px; left: 8px;
+  font-size: 11px; color:#fff;
+  background: rgba(0,0,0,.55);
+  padding: 5px 8px; border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.12);
+}
+
+/* Bottom overlay (title/desc over the video) */
+.learn-card__overlay{
+  position: absolute; left: 0; right: 0; bottom: 0;
+  padding: 10px 12px 12px;
+  background: linear-gradient(to top, rgba(0,0,0,.75) 0%, rgba(0,0,0,.0) 80%);
+}
+.learn-card__title{
+  margin: 0 0 4px; color: #fff; font-weight: 800; font-size: 1.05rem;
+  text-shadow: 0 1px 2px rgba(0,0,0,.6);
+}
+.learn-card__text{
+  margin: 0; color: #e6e6e6; font-size: .95rem; line-height: 1.4;
+}
+
+/* Placeholders: muted look, no pointer cursor */
+.yt-thumb--placeholder{ 
+  background: linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.1));
+  cursor: default;
+}
+.yt-thumb--placeholder .yt-thumb__play{ opacity: .5; }
+.yt-thumb--placeholder::after{ background: none; }
   </style>
 </head>
 <body>
@@ -403,14 +355,7 @@
           <li>You don’t pay income tax on the money you contribute</li>
           <li>Your investments grow tax‑free (no 8‑year deemed disposal)</li>
           <li>You can take a portion tax‑free at retirement</li>
-        </ul>
-        <div class="hero-video-cta">
-          <button class="yt-thumb" type="button" data-video-id="ZA58vuPH4CY" aria-haspopup="dialog" aria-controls="videoModal" aria-label="Watch a 60-second intro video">
-            <span class="yt-thumb__badge">Short • ~1 min</span>
-            <span class="yt-thumb__play" aria-hidden="true">►</span>
-          </button>
-        </div>
-      </div>
+        </ul>      </div>
     </div>
   </section>
 
@@ -439,50 +384,6 @@
       </div>
     </div>
   </section>
-
-  <section class="learn" aria-label="Learn more about Planéir">
-    <div class="learn__grid">
-
-      <!-- Card 1: 60-second intro -->
-      <article class="learn-card">
-        <button class="yt-thumb yt-thumb--wide" type="button"
-          data-video-id="ZA58vuPH4CY"
-          aria-haspopup="dialog" aria-controls="videoModal"
-          aria-label="Watch a 60-second intro video">
-          <span class="yt-thumb__badge">Short • ~1 min</span>
-          <span class="yt-thumb__play" aria-hidden="true">►</span>
-        </button>
-        <div class="learn-card__body">
-          <h3 class="learn-card__title">60-second intro</h3>
-          <p class="learn-card__text">Why pensions are the lever in Ireland and how these tools help.</p>
-        </div>
-      </article>
-
-      <!-- Card 2: Full Monty explainer (placeholder) -->
-      <article class="learn-card">
-        <div class="yt-thumb yt-thumb--wide yt-thumb--placeholder" aria-label="Full Monty explainer coming soon">
-          <span class="yt-thumb__play" aria-hidden="true">▶</span>
-        </div>
-        <div class="learn-card__body">
-          <h3 class="learn-card__title">Full Monty explainer</h3>
-          <p class="learn-card__text">A walkthrough of our all-in-one financial planning tool. Coming soon.</p>
-        </div>
-      </article>
-
-      <!-- Card 3: Individual tools explainer (placeholder) -->
-      <article class="learn-card">
-        <div class="yt-thumb yt-thumb--wide yt-thumb--placeholder" aria-label="Individual tools explainer coming soon">
-          <span class="yt-thumb__play" aria-hidden="true">▶</span>
-        </div>
-        <div class="learn-card__body">
-          <h3 class="learn-card__title">Individual tools explainer</h3>
-          <p class="learn-card__text">An overview of each tool and when to use it. Coming soon.</p>
-        </div>
-      </article>
-
-    </div>
-  </section>
-
   <!-- SECONDARY: single tools -->
   <div id="tools" class="tools-head" aria-hidden="true">
     <span class="rule"></span>
@@ -507,6 +408,54 @@
     </div>
   </div>
 
+<section class="learn" aria-label="Watch & Learn">
+  <h2 class="learn__heading">Watch & Learn</h2>
+
+  <div class="learn__grid">
+
+    <!-- Card 1: 60-second intro (live) -->
+    <article class="learn-card learn-card--portrait">
+      <button class="yt-thumb yt-thumb--tall" type="button"
+        data-video-id="ZA58vuPH4CY"
+        aria-haspopup="dialog" aria-controls="videoModal"
+        aria-label="Watch a 60-second intro video">
+        <span class="yt-thumb__badge">Short • ~1 min</span>
+        <span class="yt-thumb__play" aria-hidden="true">►</span>
+
+        <!-- Overlay text (inside the button so the whole card is clickable) -->
+        <div class="learn-card__overlay">
+          <h3 class="learn-card__title">60‑second intro</h3>
+          <p class="learn-card__text">Why pensions are the lever in Ireland.</p>
+        </div>
+      </button>
+    </article>
+
+    <!-- Card 2: Full Monty explainer (placeholder) -->
+    <article class="learn-card learn-card--portrait">
+      <div class="yt-thumb yt-thumb--tall yt-thumb--placeholder"
+        aria-label="Full Monty explainer coming soon">
+        <span class="yt-thumb__play" aria-hidden="true">▶</span>
+        <div class="learn-card__overlay">
+          <h3 class="learn-card__title">Full Monty explainer</h3>
+          <p class="learn-card__text">A walkthrough of the all‑in‑one planner. Coming soon.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- Card 3: Individual tools explainer (placeholder) -->
+    <article class="learn-card learn-card--portrait">
+      <div class="yt-thumb yt-thumb--tall yt-thumb--placeholder"
+        aria-label="Individual tools explainer coming soon">
+        <span class="yt-thumb__play" aria-hidden="true">▶</span>
+        <div class="learn-card__overlay">
+          <h3 class="learn-card__title">Individual tools explainer</h3>
+          <p class="learn-card__text">Overview of each tool and when to use it. Coming soon.</p>
+        </div>
+      </div>
+    </article>
+
+  </div>
+</section>
  </main>
 
  <div id="videoModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="videoModalTitle" hidden>
@@ -520,11 +469,30 @@
 
      <div class="modal__body">
        <div class="modal__video" data-video-mount data-video-id="ZA58vuPH4CY"></div>
-       <p class="modal__caption">A quick look at Ireland’s investing reality, why pensions are the lever, and how to get value from these tools.</p>
+       <p class="modal__caption">A quick look at Ireland’s investing reality and why pensions are the lever.</p>
      </div>
    </div>
  </div>
 
+<script>
+(function loadPortraitThumbs(){
+  const buttons = document.querySelectorAll('.yt-thumb[data-video-id]');
+  buttons.forEach(btn => {
+    const id = btn.getAttribute('data-video-id');
+    const posters = [
+      `https://i.ytimg.com/vi/${id}/maxresdefault.jpg`,
+      `https://i.ytimg.com/vi/${id}/hqdefault.jpg`
+    ];
+    (function tryLoad(i=0){
+      if(i >= posters.length) return;
+      const img = new Image();
+      img.onload  = () => btn.style.backgroundImage = `url("${posters[i]}")`;
+      img.onerror = () => tryLoad(i+1);
+      img.src = posters[i];
+    })();
+  });
+})();
+</script>
  <script>
 (function videoThumbAndModal(){
   const thumbBtns = document.querySelectorAll('.yt-thumb[data-video-id]');
@@ -536,24 +504,7 @@
   let iframeInjected = false;
   let hintEl = null;
   let currentId = null;
-
-  function loadThumb(btn){
-    const id = btn.getAttribute('data-video-id');
-    const imgs = [
-      `https://i.ytimg.com/vi/${id}/maxresdefault.jpg`,
-      `https://i.ytimg.com/vi/${id}/hqdefault.jpg`
-    ];
-    (function tryLoad(i=0){
-      if(i >= imgs.length) return;
-      const img = new Image();
-      img.onload  = () => btn.style.backgroundImage = `url("${imgs[i]}")`;
-      img.onerror = () => tryLoad(i+1);
-      img.src = imgs[i];
-    })();
-  }
-
   thumbBtns.forEach(btn => {
-    loadThumb(btn);
     btn.addEventListener('click', () => open(btn.getAttribute('data-video-id')));
   });
 


### PR DESCRIPTION
## Summary
- Replace thumbnail loader and modal caption, and strip hero video CTA
- Rework Learn section into portrait "Watch & Learn" cards positioned after the tools grid
- Add CSS/JS for portrait video cards with lazy poster loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ddb0f9148333b31f966f02fdfbf1