### PR TITLE
feat: add diversified funds step

### DIFF
--- a/styles/inputs.css
+++ b/styles/inputs.css
@@ -80,6 +80,15 @@ button.wizDot.active, button.wizDot:focus-visible{ background:#c000ff; outline:n
   outline:2px solid transparent;
 }
 
+/* fund list (step 7) */
+.stack{ display:flex; flex-direction:column; gap:1rem; }
+.fund-row{ display:grid; grid-template-columns:1fr 1fr 1fr auto; gap:.5rem; align-items:center; }
+.fund-row .errors{ grid-column:1 / -1; color:var(--danger); font-size:.9rem; margin-top:.25rem; }
+.currency{ position:relative; display:flex; align-items:center; background:var(--field-bg); border:1px solid var(--field-border); border-radius:10px; }
+.currency input{ background:transparent; border:0; color:var(--field-ink); padding:.55rem .7rem .55rem 1.6rem; width:100%; }
+.currency .prefix{ position:absolute; left:.6rem; color:var(--field-muted); }
+.currency:focus-within{ border-color:var(--focus); box-shadow:var(--focus-ring); }
+
 /* On wizard pages only */
 .wizard-controls > button{
   background:linear-gradient(135deg,#00ff88,#0099ff);


### PR DESCRIPTION
## Summary
- refactor investments step to capture multiple diversified funds with add/remove and localStorage persistence
- update data model and balance sheet to use diversified fund array
- style currency prefix for fund amount inputs

## Testing
- `node --check fullMontyWizard.js`


------
https://chatgpt.com/codex/tasks/task_e_6898eb49eee08333819976b82e9c7da4