### PR TITLE
Revamp Step 7 diversified investments UI

### DIFF
--- a/styles/inputs.css
+++ b/styles/inputs.css
@@ -84,63 +84,38 @@ button.wizDot.active, button.wizDot:focus-visible{ background:#c000ff; outline:n
 #step-7 .helper { margin-bottom: 1rem; }
 #step-7 .helper .muted { opacity:.8; }
 
-.example-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: .5rem 1rem;
-  padding: .75rem 1rem;
-  border-radius: 12px;
-  background: rgba(255,255,255,0.04);
-  margin-bottom: 1rem;
-}
-.example-row .label { opacity:.75; font-size:.85rem; }
-.example-row .value { font-weight:600; }
+/* Step 7 grid uses card-like + form-group (match global look) */
+.fund-list { display: grid; gap: 1rem; }
 
-.fund-list { display:grid; gap:1rem; }
-
+/* 3 fields + remove (desktop), stacked on mobile */
 .fund-row {
-  display:grid;
-  grid-template-columns:1.2fr 1.2fr 0.8fr auto;
-  gap:1rem;
-  align-items:end;
-  padding:1rem;
-  border-radius:14px;
-  background:rgba(255,255,255,0.03);
+  display: grid;
+  grid-template-columns: 1.2fr 1.2fr 0.8fr auto;
+  gap: 1rem;
+  align-items: end;
 }
 @media (max-width: 767px) {
-  .fund-row { grid-template-columns:1fr; }
-  .fund-row .remove { justify-self:end; margin-top:.25rem; }
+  .fund-row { grid-template-columns: 1fr; }
+  .fund-row .btn-row-remove { justify-self: end; margin-top: .25rem; }
 }
 
-.field label { display:block; font-weight:600; margin-bottom:.35rem; }
-.field .sublabel { display:block; font-weight:400; opacity:.75; font-size:.85rem; }
-.field input { width:100%; }
+/* Generic form-group to mirror other steps */
+.form-group label { display:block; font-weight:600; margin-bottom:.35rem; }
+.form-group .helper { display:block; opacity:.75; font-size:.85rem; margin-bottom:.35rem; }
+.form-group .error { color:#ff6b6b; font-size:.85rem; min-height:1.1em; margin-top:.25rem; }
 
-.currency { position:relative; }
-.currency .prefix {
-  position:absolute; left:.75rem; top:50%; transform:translateY(-50%);
-  pointer-events:none; opacity:.8;
+/* Invalid inputs reuse the same border highlight */
+.input-wrap input.invalid { outline: none; }
+.input-wrap.invalid, .input-wrap input.invalid {
+  border-color:#ff6b6b !important;
+  box-shadow:none;
 }
-.currency input { padding-left:1.75rem; width:100%; }
+
+/* Tidy total alignment on small screens */
+.actions-row { display:flex; align-items:center; justify-content:space-between; margin-top:.75rem; }
+.total { display:flex; gap:.5rem; align-items:baseline; }
 
 .error { color:#ff6b6b; font-size:.85rem; min-height:1.1em; margin-top:.25rem; }
-
-.btn-icon.remove {
-  height:40px; width:40px; border-radius:10px;
-  display:grid; place-items:center;
-  background:rgba(255,255,255,0.06);
-}
-.btn-icon.remove:hover { background:rgba(255,255,255,0.12); }
-
-.actions-row {
-  display:flex; align-items:center; justify-content:space-between;
-  margin-top:.75rem;
-}
-.total { font-size:1rem; gap:.5rem; display:flex; align-items:baseline; }
-.total strong { font-size:1.1rem; }
-
-.field input.invalid { border:1px solid #ff6b6b; }
-.currency input.invalid { border:1px solid #ff6b6b; }
 
 /* On wizard pages only */
 .wizard-controls > button{


### PR DESCRIPTION
## Summary
- Replace example fund row with dynamic card-like form groups using global input styles
- Add empty-state messaging, datalist suggestions, and accurate add-button text
- Align Step 7 styling with shared input components and simplified validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689909a57f78833398e630af5c1f9543