### PR TITLE
Remove liabilities step and add risk selection

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -56,17 +56,40 @@
     input[type=date],input[type=number],input[type=text],select{width:100%;padding:.55rem .7rem;border:1px solid transparent;border-radius:8px;background:#404040;color:#fff;}
     input::placeholder{color:#aaa;}
     input:focus,select:focus{outline:none;border-color:var(--glow);box-shadow:0 0 0 3px rgba(0,255,136,.25);}
-    .error{color:var(--danger);margin-top:.5rem;}
+    .error{color:var(--error, #ff6b6b);margin-top:.5rem;font-size:.9rem;}
 
     /* Pension risk cards */
-    .risk-grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-top:1rem;}
-    @media(max-width:480px){.risk-grid{grid-template-columns:1fr;}}
-    .risk-card{background:#353535;border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.35rem;cursor:pointer;}
-    .risk-card.selected{outline:2px solid var(--glow);box-shadow:0 0 8px var(--glow);}
-    .risk-title{font-weight:600;}
-    .risk-mix{font-size:.9rem;}
-    .risk-rate{font-size:.9rem;color:#aaa;}
-    .risk-footnote{font-size:.75rem;color:#aaa;margin-top:.75rem;}
+    .risk-grid{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:1rem;
+      margin-top:1rem;
+    }
+    @media (max-width:640px){
+      .risk-grid{grid-template-columns:1fr;}
+    }
+    .risk-card{
+      display:flex;
+      flex-direction:column;
+      align-items:flex-start;
+      gap:.25rem;
+      padding:1rem;
+      border:1px solid var(--field-border,rgba(255,255,255,.12));
+      border-radius:12px;
+      background:var(--field-bg,rgba(255,255,255,.04));
+      outline:none;
+      cursor:pointer;
+      transition:transform .08s ease, box-shadow .2s ease, border-color .2s ease;
+    }
+    .risk-card:hover{transform:translateY(-1px);}
+    .risk-card:focus{box-shadow:var(--focus-ring,0 0 0 3px rgba(0,255,136,.25));}
+    .risk-card.selected{
+      border-color:var(--focus,#00ff88);
+      box-shadow:var(--focus-ring,0 0 0 3px rgba(0,255,136,.25));
+    }
+    .risk-title{font-weight:700;}
+    .risk-mix{font-size:.9rem;opacity:.9;}
+    .risk-rate{font-size:.85rem;opacity:.8;}
 
     /* Optional: row grouping look */
     .list-wrap .asset-row{


### PR DESCRIPTION
## Summary
- drop the Liabilities step and related state from the Full Monty wizard
- append new risk/return selection cards beneath the existing Step 6 text
- style risk cards for responsive 2x2 grid and keyboard-friendly selection

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5b64e9f8833397661e04024470d8