### PR TITLE
Add drawdown charts to Full Monty results

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -172,16 +172,49 @@
     @keyframes slideInRight{from{transform:translateX(40px);opacity:0}to{transform:none;opacity:1}}
     #fmStepContainer.anim-left{animation:slideInLeft .25s ease-out both}
     #fmStepContainer.anim-right{animation:slideInRight .25s ease-out both}
-    .kpi-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin:12px 0}
+    .fm-results{
+      display:flex;
+      justify-content:center;
+      padding:2rem 1rem 4rem;
+    }
+    .results-shell{
+      width: min(1600px, calc(100vw - 64px));
+      margin: 0 auto;
+    }
+
+    /* KPIs */
+    .kpi-row{
+      display:grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+      margin: 12px 0 20px;
+    }
     .kpi-card{background:#2b2b2b;border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:12px}
     .kpi-card.ok{outline:1px solid rgba(0,255,136,.35);box-shadow:0 0 0 3px rgba(0,255,136,.15) inset}
     .kpi-card.warn{outline:1px solid rgba(255,180,0,.35);box-shadow:0 0 0 3px rgba(255,180,0,.08) inset}
     .kpi-card.danger{outline:1px solid rgba(255,77,77,.35);box-shadow:0 0 0 3px rgba(255,77,77,.08) inset}
     .kpi-label{font-size:.9rem;color:#aaa;margin-bottom:4px}
     .kpi-val{font-size:1.25rem;font-weight:800}
-    .chart-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:12px}
-    .chart-card{height:360px;background:#232323;border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:8px}
-    @media(max-width:800px){.chart-grid{grid-template-columns:1fr}.chart-card{height:300px}}
+
+    /* Charts auto-fit columns; scale with viewport height */
+    .chart-grid{
+      display:grid;
+      grid-template-columns: repeat(auto-fit, minmax(460px, 1fr));
+      gap: 16px;
+      margin-top: 12px;
+    }
+    .chart-card{
+      height: clamp(340px, 42vh, 620px);
+      background:#232323;
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:12px;
+      padding:8px;
+    }
+
+    @media(max-width: 980px){
+      .kpi-row{ grid-template-columns: 1fr; }
+      .chart-grid{ grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -207,10 +240,17 @@
     </div>
   </div>
   <section id="fullMontyResults" class="fm-results">
-    <div id="kpis" class="kpi-row"></div>
-    <div class="chart-grid">
-      <div class="chart-card"><canvas id="growthChart"></canvas></div>
-      <div class="chart-card"><canvas id="contribChart"></canvas></div>
+    <div class="results-shell">
+      <div id="kpis" class="kpi-row"></div>
+
+      <div class="chart-grid">
+        <div class="chart-card"><canvas id="growthChart"></canvas></div>
+        <div class="chart-card"><canvas id="contribChart"></canvas></div>
+
+        <!-- NEW: retirement-phase charts (drawdown) -->
+        <div class="chart-card"><canvas id="ddBalanceChart"></canvas></div>
+        <div class="chart-card"><canvas id="ddCashflowChart"></canvas></div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Expand Full Monty results layout and add drawdown canvases for retirement-phase visuals
- Compute drawdown using FY assumptions and render balance and cashflow charts
- Capture FY inputs for reuse in drawdown simulations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9ebe10588333972b1fa9424832ed