### PR TITLE
feat: add pension projections and drawdown charts

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -172,17 +172,18 @@
     @keyframes slideInRight{from{transform:translateX(40px);opacity:0}to{transform:none;opacity:1}}
     #fmStepContainer.anim-left{animation:slideInLeft .25s ease-out both}
     #fmStepContainer.anim-right{animation:slideInRight .25s ease-out both}
+    /* Results wrapper */
     .fm-results{
       display:flex;
       justify-content:center;
       padding:2rem 1rem 4rem;
     }
     .results-shell{
-      width: min(1600px, calc(100vw - 64px));
+      width: clamp(1024px, 95vw, 1800px);
       margin: 0 auto;
     }
 
-    /* KPIs */
+    /* KPI cards: stick to 3 across on desktop */
     .kpi-row{
       display:grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -196,24 +197,25 @@
     .kpi-label{font-size:.9rem;color:#aaa;margin-bottom:4px}
     .kpi-val{font-size:1.25rem;font-weight:800}
 
-    /* Charts auto-fit columns; scale with viewport height */
+    /* Charts: exactly 2 columns on desktop, stack below 1100px */
     .chart-grid{
       display:grid;
-      grid-template-columns: repeat(auto-fit, minmax(460px, 1fr));
+      grid-template-columns: repeat(2, minmax(540px, 1fr));
       gap: 16px;
       margin-top: 12px;
     }
     .chart-card{
-      height: clamp(340px, 42vh, 620px);
+      height: clamp(360px, 46vh, 560px);
       background:#232323;
       border:1px solid rgba(255,255,255,.08);
       border-radius:12px;
       padding:8px;
     }
-
-    @media(max-width: 980px){
-      .kpi-row{ grid-template-columns: 1fr; }
+    @media (max-width: 1100px){
       .chart-grid{ grid-template-columns: 1fr; }
+    }
+    @media (max-width: 900px){
+      .kpi-row{ grid-template-columns: 1fr; }
     }
   </style>
 </head>

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -1,25 +1,65 @@
-import { projectPension } from './shared/projectPension.js';
+// pensionProjection.js
+const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+const yrDiff = (d, ref = new Date()) => (ref - d) / (1000*60*60*24*365.25);
 
-// Listens for fm-run-pension and emits fm-pension-output
-// so the Full Monty results page can render projections.
+// Listens for fm-run-pension and emits fm-pension-output so
+// the Full Monty results page can render projections.
 document.addEventListener('fm-run-pension', (e) => {
-  try {
-    const args = e.detail || {};
-    const out = projectPension(args);
-    document.dispatchEvent(new CustomEvent('fm-pension-output', { detail: out }));
-  } catch (err) {
-    console.error('[pensionProjection] failed to project', err);
-    const balances = [{ age: 0, value: 0 }];
-    document.dispatchEvent(new CustomEvent('fm-pension-output', {
-      detail: {
-        balances,
-        projValue: 0,
-        retirementYear: new Date().getFullYear(),
-        contribsBase: [0],
-        growthBase: [0],
-        showMax: false
-      }
-    }));
+  const d = e.detail || {};
+  const now = new Date();
+  const dob = d.dob ? new Date(d.dob) : null;
+  const curAge = dob ? yrDiff(dob, now) : 40;
+  const retireAge = clamp(+d.retireAge || 65, 50, 70);
+  const years = Math.max(0, Math.round(retireAge - curAge));
+  const startAge = Math.round(curAge);
+  const retirementYear = now.getFullYear() + Math.ceil(Math.max(0, retireAge - curAge));
+
+  const salary = Math.max(0, +d.salary || 0);
+  const growth = Number.isFinite(+d.growth) ? +d.growth : 0.05;
+
+  const personalAbs = Math.max(0, +d.personalContrib || 0);
+  const employerAbs = Math.max(0, +d.employerContrib || 0);
+  const personalPct = Math.max(0, +d.personalPct || 0);
+  const employerPct = Math.max(0, +d.employerPct || 0);
+
+  const annualContrib =
+    personalAbs + employerAbs + (personalPct/100)*salary + (employerPct/100)*salary;
+
+  let bal = Math.max(0, +d.currentValue || 0);
+
+  const balances = [];
+  const contribsBase = [];
+  const growthBase = [];
+
+  for (let i = 0; i <= years; i++) {
+    const age = Math.round(curAge + i);
+    balances.push({ age, value: Math.round(bal) });
+
+    if (i < years) {
+      const contrib = Math.max(0, annualContrib);
+      const grow = Math.max(0, bal * growth);
+
+      contribsBase.push(Math.round(contrib));
+      growthBase.push(Math.round(grow));
+
+      bal = bal + contrib + grow;
+    }
   }
+
+  const projValue = balances.at(-1)?.value || 0;
+
+  const payload = {
+    balances,                 // [{age, value}, …]
+    projValue,                // value at retirement
+    retirementYear,
+    contribsBase,
+    growthBase,
+    // Optional/neutral defaults used by results JS:
+    showMax: false,
+    sftLimit: undefined,
+    growth
+  };
+
+  document.dispatchEvent(new CustomEvent('fm-pension-output', { detail: payload }));
 });
 


### PR DESCRIPTION
## Summary
- add pensionProjection.js to emit `fm-pension-output`
- enforce desktop 2×2 chart grid with KPI row and new script order
- add retirement drawdown depletion marker and input guards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check pensionProjection.js`
- `node --check fullMontyResults.js`


------
https://chatgpt.com/codex/tasks/task_e_689fa41f81248333bdd04850933eaa5c