### PR TITLE
Add max-contribution scenario toggle to Full Monty results

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -217,6 +217,64 @@
     @media (max-width: 900px){
       .kpi-row{ grid-template-columns: 1fr; }
     }
+
+    /* Summary strip */
+    .summary-row{
+      margin: 6px 0 10px;
+      padding: 12px 14px;
+      border-radius: 12px;
+      background: #232323;
+      border: 1px solid rgba(255,255,255,.08);
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 12px;
+      align-items: center;
+    }
+    .summary-row .headline{
+      font-weight: 800;
+      font-size: 1.05rem;
+    }
+    .summary-row.ok{ box-shadow: 0 0 0 3px rgba(0,255,136,.12) inset; }
+    .summary-row.warn{ box-shadow: 0 0 0 3px rgba(255,180,0,.12) inset; }
+    .summary-row.danger{ box-shadow: 0 0 0 3px rgba(255,77,77,.12) inset; }
+    .summary-row .actions{ display:flex; gap:.5rem; }
+    .summary-row .action-btn{
+      background:#2f2f2f;border:1px solid rgba(255,255,255,.14);
+      color:#ddd;border-radius:999px;padding:.45rem .8rem; font-weight:700;
+    }
+
+    /* Controls row + pill switch */
+    .controls-row{ display:flex; align-items:center; gap:12px; margin: 6px 0 8px; }
+
+    .pill-switch{ position:relative; display:inline-flex; align-items:center; cursor:pointer; }
+    .pill-switch input{ display:none; }
+    .pill-switch .track{
+      position:relative; display:inline-flex; align-items:center; gap:10px;
+      background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.14);
+      height:36px; border-radius:999px; padding:0 12px 0 42px;
+      color:#ddd; font-weight:700; min-width: 160px;
+    }
+    .pill-switch .thumb{
+      position:absolute; left:6px; top:4px; width:28px; height:28px;
+      border-radius:50%; background:#666; transition: transform .18s ease, background .2s ease;
+    }
+    .pill-switch input:checked + .track{ border-color: rgba(0,255,136,.45); box-shadow: 0 0 0 3px rgba(0,255,136,.18); }
+    .pill-switch input:checked + .track .thumb{ transform: translateX(118px); background:#00ff88; }
+    .pill-switch .label-on, .pill-switch .label-off{ font-size:.95rem; }
+    .pill-switch .label-off{ opacity:.85; }
+    .pill-switch input:checked + .track .label-off{ opacity:0; }
+    .pill-switch input:checked + .track .label-on{ opacity:1; }
+
+    /* Floating “Change My Inputs” button */
+    .floating-edit{
+      position: fixed; right: 22px; bottom: 22px; z-index: 20;
+      background:#00a86b; color:#fff; border:0; border-radius:999px;
+      padding:.9rem 1.1rem; font-weight:800; box-shadow: 0 10px 30px rgba(0,168,107,.35);
+    }
+    .floating-edit:hover{ filter: brightness(1.05); transform: translateY(-1px); }
+
+    /* Short, friendly captions under charts (optional hooks) */
+    .chart-card .caption{ color:#bdbdbd; font-size:.9rem; margin-top:6px; }
   </style>
 </head>
 <body>
@@ -243,6 +301,21 @@
   </div>
   <section id="fullMontyResults" class="fm-results">
     <div class="results-shell">
+      <!-- Top Summary / Actions row -->
+      <div id="resultsSummary" class="summary-row" aria-live="polite"></div>
+
+      <!-- Controls row -->
+      <div class="controls-row">
+        <label class="pill-switch" title="Show projection if you made the maximum personal contributions allowed by age band">
+          <input id="maxContribToggle" type="checkbox" />
+          <span class="track">
+            <span class="thumb"></span>
+            <span class="label-on">Max contribs</span>
+            <span class="label-off">Max contribs</span>
+          </span>
+        </label>
+      </div>
+
       <div id="kpis" class="kpi-row"></div>
 
       <div class="chart-grid">
@@ -254,6 +327,8 @@
         <div class="chart-card"><canvas id="ddCashflowChart"></canvas></div>
       </div>
     </div>
+
+    <button id="editPlanBtn" class="floating-edit">Change My Inputs</button>
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>

--- a/pensionProjection.js
+++ b/pensionProjection.js
@@ -1,6 +1,18 @@
 // pensionProjection.js
+import { MAX_SALARY_CAP } from './shared/assumptions.js';
+
 const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
 const yrDiff = (d, ref = new Date()) => (ref - d) / (1000*60*60*24*365.25);
+
+const AGE_BANDS = [
+  { max: 29,  pct: 0.15 },
+  { max: 39,  pct: 0.20 },
+  { max: 49,  pct: 0.25 },
+  { max: 54,  pct: 0.30 },
+  { max: 59,  pct: 0.35 },
+  { max: 120, pct: 0.40 }
+];
+const maxPctForAge = (age) => AGE_BANDS.find(b => age <= b.max).pct;
 
 // Listens for fm-run-pension and emits fm-pension-output so
 // the Full Monty results page can render projections.
@@ -9,21 +21,23 @@ document.addEventListener('fm-run-pension', (e) => {
   const now = new Date();
   const dob = d.dob ? new Date(d.dob) : null;
   const curAge = dob ? yrDiff(dob, now) : 40;
-  const retireAge = clamp(+d.retireAge || 65, 50, 70);
+  const retireAge = clamp(+d.retireAge || 65, 50, 75);
   const years = Math.max(0, Math.round(retireAge - curAge));
   const startAge = Math.round(curAge);
   const retirementYear = now.getFullYear() + Math.ceil(Math.max(0, retireAge - curAge));
 
-  const salary = Math.max(0, +d.salary || 0);
+  const salaryRaw = Math.max(0, +d.salary || 0);
+  const salaryCapped = Math.min(salaryRaw, MAX_SALARY_CAP);
+
   const growth = Number.isFinite(+d.growth) ? +d.growth : 0.05;
 
   const personalAbs = Math.max(0, +d.personalContrib || 0);
   const employerAbs = Math.max(0, +d.employerContrib || 0);
-  const personalPct = Math.max(0, +d.personalPct || 0);
-  const employerPct = Math.max(0, +d.employerPct || 0);
+  const personalPct = Math.max(0, +d.personalPct || 0) / 100;
+  const employerPct = Math.max(0, +d.employerPct || 0) / 100;
 
-  const annualContrib =
-    personalAbs + employerAbs + (personalPct/100)*salary + (employerPct/100)*salary;
+  const basePersonal = personalAbs || salaryCapped * personalPct;
+  const baseEmployer = employerAbs || salaryRaw * employerPct;
 
   let bal = Math.max(0, +d.currentValue || 0);
 
@@ -31,33 +45,52 @@ document.addEventListener('fm-run-pension', (e) => {
   const contribsBase = [];
   const growthBase = [];
 
+  // base scenario
   for (let i = 0; i <= years; i++) {
     const age = Math.round(curAge + i);
     balances.push({ age, value: Math.round(bal) });
-
     if (i < years) {
-      const contrib = Math.max(0, annualContrib);
+      const contrib = Math.max(0, basePersonal + baseEmployer);
       const grow = Math.max(0, bal * growth);
-
       contribsBase.push(Math.round(contrib));
       growthBase.push(Math.round(grow));
-
       bal = bal + contrib + grow;
     }
   }
-
   const projValue = balances.at(-1)?.value || 0;
 
+  // max scenario
+  let maxBal = Math.max(0, +d.currentValue || 0);
+  const maxBalances = [];
+  const contribsMax = [];
+  const growthMax = [];
+
+  for (let i = 0; i <= years; i++) {
+    const age = Math.round(curAge + i);
+    maxBalances.push({ age, value: Math.round(maxBal) });
+    if (i < years) {
+      const personalMax = maxPctForAge(curAge + i + 1) * salaryCapped;
+      const contrib = Math.max(0, personalMax + baseEmployer);
+      const grow = Math.max(0, maxBal * growth);
+      contribsMax.push(Math.round(contrib));
+      growthMax.push(Math.round(grow));
+      maxBal = maxBal + contrib + grow;
+    }
+  }
+
   const payload = {
-    balances,                 // [{age, value}, …]
-    projValue,                // value at retirement
+    balances,                 // base [{age, value}]
+    projValue,                // base value at retirement
     retirementYear,
     contribsBase,
     growthBase,
-    // Optional/neutral defaults used by results JS:
-    showMax: false,
-    sftLimit: undefined,
-    growth
+    // max scenario (for toggle)
+    maxBalances,
+    contribsMax,
+    growthMax,
+    // remember growth for drawdown sim
+    growth,
+    showMax: false
   };
 
   document.dispatchEvent(new CustomEvent('fm-pension-output', { detail: payload }));


### PR DESCRIPTION
## Summary
- Add top summary strip, max contributions toggle, and sticky input-edit button to results page
- Extend pension projection engine to calculate max personal contribution scenario
- Update results controller to switch KPIs, charts, and drawdown based on active scenario with plain-language captions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check pensionProjection.js`
- `node --check fullMontyResults.js`


------
https://chatgpt.com/codex/tasks/task_e_689fa9ff3a648333acf4d6ad63e0d279