### PR TITLE
Add max contributions toggle and age-band breakdown

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -243,89 +243,87 @@
       color:#ddd;border-radius:999px;padding:.45rem .8rem; font-weight:700;
     }
 
+    /* ───── Max toggle ───────────────────────────────────────── */
     .max-toggle-row{
-      display:flex; align-items:center; gap:16px; margin: 8px 0 16px;
+      display:flex; align-items:center; gap:16px; margin:12px 0 6px;
     }
-
     .toggle{
-      --h: 44px;
-      --w: 420px;              /* wide so label fits; shrinks on small screens */
-      --pad: 4px;
-      --on: #00ff88;           /* glow */
-      --off: #3f3f3f;
-      --ring: rgba(0,255,136,.25);
-      position: relative; display:inline-flex; align-items:center;
+      --w: 540px;           /* pill width */
+      --h: 52px;            /* pill height */
+      --pad: 6px;           /* inner padding for the thumb */
+      --on:  #00ff88;       /* thumb ON color */
+      --off: #5f5f5f;       /* thumb OFF color */
+      display:inline-block; position:relative;
+      width:var(--w); height:var(--h); cursor:pointer;
     }
-    .toggle input{ position:absolute; opacity:0; pointer-events:none; }
+    .toggle input{ position:absolute; inset:0; opacity:0; }
     .toggle .track{
-      position:relative; width:var(--w); min-width:260px; height:var(--h);
-      border-radius:999px; background:#1f1f1f; outline:1px solid rgba(255,255,255,.08);
-      box-shadow: inset 0 0 0 2px rgba(255,255,255,.06);
-      display:flex; align-items:center; justify-content:center; overflow:hidden;
-      padding:0 var(--h);                      /* space for the thumb both sides */
-      transition: box-shadow .2s ease, outline-color .2s ease;
+      position:absolute; inset:0; border-radius:999px;
+      background:#1f1f1f;
+      box-shadow: inset 0 0 0 2px rgba(0,255,136,.18);
+      display:flex; align-items:center; justify-content:center;
+      padding:0 60px;             /* space for thumb at ends */
     }
-    .toggle .label-off, .toggle .label-on{
-      position:absolute; left:0; right:0; text-align:center;
-      font-weight:800; color:#cfcfcf; opacity:1; transition: opacity .15s ease;
-      pointer-events:none; user-select:none; padding:0 16px;
-      white-space:nowrap; text-overflow:ellipsis; overflow:hidden;
+    .toggle .label{
+      font-weight:800; letter-spacing:.2px; color:#ddd;
+      pointer-events:none; user-select:none;
     }
-    .toggle .label-on{ opacity:.0; }
-
     .toggle .thumb{
       position:absolute; top:var(--pad); bottom:var(--pad);
-      width: calc(var(--h) - var(--pad)*2); border-radius:50%;
-      background: var(--off); box-shadow: inset 0 0 0 1px rgba(255,255,255,.15);
-      transform: translateX(calc(-50% + var(--pad)));
-      left: calc(var(--h) / 2);            /* centers starting at far-left edge */
-      transition: transform .25s cubic-bezier(.2,.8,.2,1), background .2s ease,
-                  box-shadow .2s ease;
+      width: calc(var(--h) - var(--pad)*2);
+      border-radius:50%;
+      background: var(--off);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,.15);
+      left: var(--pad);                       /* start hard-left */
+      transition: left .25s cubic-bezier(.2,.8,.2,1), background .2s ease, box-shadow .2s ease;
+      will-change: left, background;
     }
-
-    /* ON state */
     .toggle input:checked + .track{
-      outline-color: rgba(0,255,136,.35);
-      box-shadow: 0 0 0 3px var(--ring) inset, 0 0 0 1px rgba(0,255,136,.25);
+      box-shadow: inset 0 0 0 2px rgba(0,255,136,.35);
     }
-    .toggle input:checked + .track .label-off{ opacity:0; }
-    .toggle input:checked + .track .label-on{ opacity:1; }
     .toggle input:checked + .track .thumb{
       background: var(--on);
-      transform: translateX(calc(var(--w) - var(--h) + 50% - var(--pad))); /* full travel */
+      left: calc(var(--w) - var(--h) + var(--pad));   /* full travel, full circle visible */
     }
 
-    /* Focus/keyboard */
-    .toggle:has(input:focus-visible) .track{
-      box-shadow: 0 0 0 3px var(--ring);
-    }
+    /* Note next to toggle */
+    .max-note{ color:#a7ffd9; font-weight:700; }
 
-    /* Inline note */
-    .max-note{
-      color:#9feecb; font-size:.95rem; font-weight:600;
-    }
-
-    /* Table container below charts */
+    /* ───── Breakdown table ─────────────────────────────────── */
     .max-breakdown{
-      margin-top: 20px;
-      background:#232323; border:1px solid rgba(255,255,255,.08);
-      border-radius:12px; padding:16px;
+      margin-top: 18px;
+      background:#242424;
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:12px;
+      padding: 10px 10px 14px;
     }
-    .max-breakdown h3{ margin:0 0 12px; font-weight:800; }
+    .max-breakdown h3{
+      margin: 8px 10px 10px;
+      font-size: 1.05rem;
+      color: #bfffe9;
+    }
     .max-breakdown .table-scroll{ overflow:auto; border-radius:10px; }
     .max-breakdown table{
-      width:100%; border-collapse:collapse; min-width:520px;
+      width:100%; border-collapse: collapse; min-width:540px;
+      background:#2d2d2d;
     }
     .max-breakdown thead th{
-      text-align:left; background:#2b2b2b; padding:10px 12px; border-bottom:1px solid rgba(255,255,255,.08);
+      background:#3a3a3a; color:#ddd; text-align:left;
+      padding:.7rem .9rem; font-weight:800;
+      border-bottom:1px solid rgba(255,255,255,.08);
     }
     .max-breakdown tbody td{
-      padding:10px 12px; border-bottom:1px solid rgba(255,255,255,.06);
+      padding:.7rem .9rem; border-bottom:1px solid rgba(255,255,255,.06);
+      color:#e8e8e8;
     }
-    .max-breakdown tr.highlight{ background:#273529; }
-    .max-breakdown .footnote{ color:#aaa; margin-top:10px; font-size:.9rem; }
-    @media (max-width: 640px){
-      .toggle{ --w: 320px; }
+    .max-breakdown tbody tr:nth-child(even){ background:#292929; }
+    .max-breakdown tbody tr.highlight{
+      background:#0d3a2d; color:#fff;
+    }
+    .max-breakdown tbody tr.highlight td:nth-child(3),
+    .max-breakdown tbody tr.highlight td:nth-child(2){ font-weight:800; }
+    .max-breakdown .footnote{
+      margin:.7rem .2rem 0; color:#bfbfbf; font-size:.92rem;
     }
 
     /* Floating “Change My Inputs” button */
@@ -369,17 +367,16 @@
 
       <div id="kpis" class="kpi-row"></div>
 
-      <!-- Toggle: max pension contributions -->
+      <!-- Toggle row -->
       <div class="max-toggle-row">
-        <label class="toggle" id="maxContribsToggle">
-          <input type="checkbox" id="useMaxContribs" aria-label="Use max pension contributions" />
+        <label class="toggle" id="useMaxToggle">
+          <input id="useMaxContribs" type="checkbox" />
           <span class="track">
-            <span class="label-off">Use max pension contributions</span>
-            <span class="label-on">Use max pension contributions</span>
+            <span class="label">Use max pension contributions</span>
             <span class="thumb" aria-hidden="true"></span>
           </span>
         </label>
-        <div id="maxContribsNote" class="max-note" aria-live="polite"></div>
+        <div id="maxToggleNote" class="max-note" aria-live="polite"></div>
       </div>
 
       <div class="chart-grid">
@@ -391,9 +388,8 @@
         <div class="chart-card"><canvas id="ddCashflowChart"></canvas></div>
       </div>
 
-      <div id="maxContribsBreakdown" class="max-breakdown" hidden>
-        <!-- JS will populate: heading + table + footnote -->
-      </div>
+      <!-- Breakdown table goes at the bottom -->
+      <section id="maxContribsBreakdown" class="max-breakdown" hidden></section>
     </div>
 
     <button id="editPlanBtn" class="floating-edit">Change My Inputs</button>


### PR DESCRIPTION
## Summary
- add pill-style "Use max pension contributions" toggle with note and breakdown link
- recompute charts and drawdown using max personal limits when toggled
- render detailed age-band table with salary cap and current-band highlight

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check fullMontyResults.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0c87941408333add8c0573c3c8d1d