### PR TITLE
Add interactive chart tooltips and depletion messaging

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -204,7 +204,7 @@
       gap: 16px;
       margin-top: 12px;
     }
-    .chart-card{
+    .chart-wrapper{
       height: clamp(360px, 46vh, 560px);
       background:#232323;
       border:1px solid rgba(255,255,255,.08);
@@ -361,8 +361,86 @@
     .max-table tr.highlight{ background:#095b45 !important; color:#fff; }
     .max-note{ margin-top:8px; color:#bbb; }
 
+    /* ===== Chart helper UI (headline + info tooltip) ===== */
+    .chart-wrapper {
+      position: relative;
+      margin-bottom: 2rem;
+    }
+
+    .chart-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: .5rem;
+    }
+
+    .chart-headline {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin: 0;
+      color: #fff;
+    }
+
+    .info-icon {
+      background: #333;
+      color: #fff;
+      border-radius: 50%;
+      width: 22px;
+      height: 22px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: .9rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.1s ease;
+      user-select: none;
+    }
+    .info-icon:hover,
+    .info-icon:focus {
+      background: #00ff88; /* neon highlight */
+      color: #000;
+      outline: none;
+      transform: translateY(-1px);
+    }
+
+    .tooltip-box {
+      position: absolute;
+      top: 40px;
+      right: 0;
+      background: #232323;
+      color: #fff;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      padding: 1rem;
+      border-radius: 12px;
+      box-shadow: 0 10px 24px rgba(0,0,0,.35);
+      max-width: 320px;
+      display: none;
+      z-index: 100;
+      animation: fadeSlideIn 0.18s ease-in-out;
+    }
+
+    .tooltip-box p {
+      margin: 0 0 .8rem 0;
+    }
+    .tooltip-box p:last-child { margin-bottom: 0; }
+
+    @keyframes fadeSlideIn {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Mobile adjustments */
+    @media (max-width: 600px) {
+      .tooltip-box {
+        max-width: 90vw;
+        right: 5%;
+      }
+    }
+
     /* Short, friendly captions under charts (optional hooks) */
-    .chart-card .caption{ color:#bdbdbd; font-size:.9rem; margin-top:6px; }
+    /* (deprecated: captions replaced by info tooltips) */
   </style>
 </head>
 <body>
@@ -409,12 +487,92 @@
       </div>
 
       <div class="chart-grid">
-        <div class="chart-card"><canvas id="growthChart"></canvas></div>
-        <div class="chart-card"><canvas id="contribChart"></canvas></div>
+        <div class="chart-wrapper" id="chart-pension-value">
+          <div class="chart-header">
+            <h3 class="chart-headline">Will my pension reach my Financial Freedom Target?</h3>
+            <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
+          </div>
+          <canvas id="growthChart"></canvas>
+          <div class="tooltip-box" role="tooltip">
+            <p class="tooltip-text pv-default">
+              This line shows how your pension could grow over time if you keep contributing as you are.
+            </p>
+            <p class="tooltip-text pv-max" style="display:none;">
+              This line shows how your pension could grow over time if you make the maximum allowable pension contributions based on your salary.
+            </p>
+            <p class="tooltip-text">
+              The purple dotted line is your <strong>Financial Freedom Target</strong> — the amount needed to support your estimated income requirement in retirement all the way to age 100.
+            </p>
+            <p class="tooltip-text">
+              The red line is the government’s pension cap (<strong>Standard Fund Threshold</strong>).
+            </p>
+            <p class="tooltip-text">
+              If your curve rises above the purple line, you’re on track for financial freedom. If it rises above the red line, you may face extra tax rules.
+            </p>
+            <div class="conditional-slot"></div>
+          </div>
+        </div>
 
-        <!-- NEW: retirement-phase charts (drawdown) -->
-        <div class="chart-card"><canvas id="ddBalanceChart"></canvas></div>
-        <div class="chart-card"><canvas id="ddCashflowChart"></canvas></div>
+        <div class="chart-wrapper" id="chart-annual-contrib">
+          <div class="chart-header">
+            <h3 class="chart-headline">How much comes from me vs. my money working for me?</h3>
+            <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
+          </div>
+          <canvas id="contribChart"></canvas>
+          <div class="tooltip-box" role="tooltip">
+            <p class="tooltip-text ac-default">
+              The green bars are the contributions you make each year. The orange bars show how your money grows once invested.
+            </p>
+            <p class="tooltip-text ac-max" style="display:none;">
+              The blue bars are the maximum pension contributions you could make each year. The orange bars show how your money grows once invested.
+            </p>
+            <p class="tooltip-text">
+              This highlights the power of compounding — your money earning money — which becomes a major driver of your pension’s long-term growth.
+            </p>
+          </div>
+        </div>
+
+        <div class="chart-wrapper" id="chart-retirement-balance">
+          <div class="chart-header">
+            <h3 class="chart-headline">Will my pension last to age 100?</h3>
+            <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
+          </div>
+          <canvas id="ddBalanceChart"></canvas>
+          <div class="tooltip-box" role="tooltip">
+            <p class="tooltip-text">
+              This chart shows your projected pension balance throughout retirement.
+            </p>
+            <p class="tooltip-text">
+              The purple dotted line starts at your <strong>Financial Freedom Target</strong> — the amount needed to meet your estimated income requirement until age 100 — and shows how that target would gradually deplete over time.
+            </p>
+            <p class="tooltip-text rb-default">
+              The green curve shows how your pension could perform at retirement if you keep contributing as you are, and how long it might last.
+            </p>
+            <p class="tooltip-text rb-max" style="display:none;">
+              The blue curve shows how your pension could perform at retirement if you make the maximum allowable contributions, and how long it might last.
+            </p>
+            <div class="conditional-slot"></div>
+          </div>
+        </div>
+
+        <div class="chart-wrapper" id="chart-retirement-income">
+          <div class="chart-header">
+            <h3 class="chart-headline">Will my income cover my lifestyle in retirement?</h3>
+            <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
+          </div>
+          <canvas id="ddCashflowChart"></canvas>
+          <div class="tooltip-box" role="tooltip">
+            <p class="tooltip-text">
+              This chart shows the income you could draw from your pension each year, along with any other retirement income sources (such as State Pension or rental income).
+            </p>
+            <p class="tooltip-text">
+              The line above represents your estimated income requirement in retirement, which gradually rises due to inflation.
+            </p>
+            <p class="tooltip-text">
+              The aim is for your combined income sources to meet or exceed this requirement each year.
+            </p>
+          </div>
+        </div>
       </div>
 
       <!-- Max table section (bottom of page) -->
@@ -426,6 +584,86 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
+  <script>
+    (function initChartInfoUI(){
+      const wrappers = document.querySelectorAll('.chart-wrapper');
+
+      wrappers.forEach(wrapper => {
+        const icon = wrapper.querySelector('.info-icon');
+        const tooltip = wrapper.querySelector('.tooltip-box');
+        if (!icon || !tooltip) return;
+
+        // Hover (desktop)
+        icon.addEventListener('mouseenter', () => { tooltip.style.display = 'block'; });
+        icon.addEventListener('mouseleave', () => { tooltip.style.display = 'none'; });
+
+        // Click/tap toggle (mobile + accessibility)
+        icon.addEventListener('click', (e) => {
+          e.stopPropagation();
+          tooltip.style.display = (tooltip.style.display === 'block') ? 'none' : 'block';
+        });
+
+        // Close when clicking outside
+        document.addEventListener('click', (e) => {
+          if (!wrapper.contains(e.target)) tooltip.style.display = 'none';
+        });
+
+        // Keyboard access
+        icon.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            tooltip.style.display = (tooltip.style.display === 'block') ? 'none' : 'block';
+          }
+          if (e.key === 'Escape') {
+            tooltip.style.display = 'none';
+            icon.blur();
+          }
+        });
+      });
+
+      // Toggle-aware text visibility helper
+      function toggleTextFor(selectorPairs, isMaxOn){
+        selectorPairs.forEach(({defaultSel, maxSel}) => {
+          const defaultEl = document.querySelector(defaultSel);
+          const maxEl = document.querySelector(maxSel);
+          if (!defaultEl || !maxEl) return;
+          defaultEl.style.display = isMaxOn ? 'none' : 'block';
+          maxEl.style.display     = isMaxOn ? 'block' : 'none';
+        });
+      }
+
+      // Public: set wording for max-toggle across all charts
+      window.setMaxToggle = function(isMaxOn){
+        toggleTextFor([
+          { defaultSel: '#chart-pension-value .pv-default', maxSel: '#chart-pension-value .pv-max' },
+          { defaultSel: '#chart-annual-contrib .ac-default', maxSel: '#chart-annual-contrib .ac-max' },
+          { defaultSel: '#chart-retirement-balance .rb-default', maxSel: '#chart-retirement-balance .rb-max' },
+        ], isMaxOn);
+      };
+
+      // Public: insert depletion messages for Retirement Balance (conditional, data-driven)
+      window.updateRetirementBalanceConditions = function({ depletionAgeCurrent = null, depletionAgeMax = null } = {}){
+        const slot = document.querySelector('#chart-retirement-balance .conditional-slot');
+        if (!slot) return;
+        slot.innerHTML = '';
+
+        if (typeof depletionAgeCurrent === 'number') {
+          const p = document.createElement('p');
+          p.className = 'tooltip-text';
+          p.innerHTML = `Your pension could deplete around age <strong>${depletionAgeCurrent}</strong>. This risk could be improved by maximising contributions.`;
+          slot.appendChild(p);
+        }
+
+        if (typeof depletionAgeMax === 'number') {
+          const p = document.createElement('p');
+          p.className = 'tooltip-text';
+          p.innerHTML = `Even maximising contributions may not be enough to meet your Financial Freedom Target (depletion around age <strong>${depletionAgeMax}</strong>). A coordinated pension and personal investment strategy may be required — professional advice is strongly recommended.`;
+          slot.appendChild(p);
+        }
+      };
+
+    })();
+  </script>
 
   <!-- listener that handles fm-run-pension and emits fm-pension-output -->
   <script type="module" src="./pensionProjection.js"></script>


### PR DESCRIPTION
## Summary
- Style chart tooltips and headers for all four results charts and wrap canvases with accessible markup
- Add tooltip interaction script exposing `setMaxToggle` and `updateRetirementBalanceConditions`
- Wire toggle and drawdown logic to update chart tooltips and show depletion warnings

## Testing
- `node --check fullMontyResults.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e0498368833399fd0848ffee474a