### PR TITLE
refactor: isolate pension risk options and add diagnostics

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -5,7 +5,7 @@
 
 import { animate, addKeyboardNav } from './wizardCore.js';
 import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
-import { renderStepPensionRisk, RISK_OPTIONS } from './stepPensionRisk.js';
+import { renderStepPensionRisk } from './stepPensionRisk.js';
 import { MAX_SALARY_CAP } from './shared/assumptions.js';
 
 // Temporary debug flag: set true to emit fake pension output without engine
@@ -53,9 +53,11 @@ function queueSave(){ clearTimeout(saveTimer); saveTimer = setTimeout(saveStore,
 // ----------------------------------------------------------------
 
 const storedRiskKey = localStorage.getItem('fm.pensionRiskKey');
+const storedRiskLabel = localStorage.getItem('fm.pensionRiskLabel');
 const storedRiskRate = parseFloat(localStorage.getItem('fm.pensionGrowthRate'));
-const defaultRiskKey = storedRiskKey && RISK_OPTIONS[storedRiskKey] ? storedRiskKey : null;
+const defaultRiskKey = storedRiskKey || null;
 const defaultRiskRate = !isNaN(storedRiskRate) ? storedRiskRate : null;
+const defaultRiskLabel = storedRiskLabel || null;
 
 const fullMontyStore = {
   // household
@@ -97,7 +99,7 @@ const fullMontyStore = {
 
 
   // risk profile
-  pensionRisk: defaultRiskKey ? RISK_OPTIONS[defaultRiskKey].label : null,
+  pensionRisk: defaultRiskLabel,
   pensionRiskKey: defaultRiskKey,
   pensionGrowthRate: defaultRiskRate,
 
@@ -680,6 +682,7 @@ const baseSteps = [
       const sel = document.createElement('div');
       sel.id = 'risk-selection';
       cont.appendChild(sel);
+      console.debug('[fullMontyWizard] renderStepPensionRisk Step 6');
       renderStepPensionRisk(sel, fullMontyStore, setStore, btnNext);
     },
     validate(){ return renderStepPensionRisk.validate(); }
@@ -708,6 +711,7 @@ function refreshSteps(){
   if(!showRisk){
     setStore({ pensionRisk: 'Not applicable (DB only)', pensionRiskKey: 'dbOnly', pensionGrowthRate: 0 });
     localStorage.setItem('fm.pensionRiskKey','dbOnly');
+    localStorage.setItem('fm.pensionRiskLabel','Not applicable (DB only)');
     localStorage.setItem('fm.pensionGrowthRate','0');
   }
 }

--- a/riskOptions.js
+++ b/riskOptions.js
@@ -1,0 +1,8 @@
+export const RISK_OPTIONS = {
+  low:      { label: 'Low risk',      mix: '≈ 30% stocks / 70% bonds', rate: 0.04 },
+  balanced: { label: 'Balanced',      mix: '≈ 50% stocks / 50% bonds', rate: 0.05 },
+  high:     { label: 'High risk',     mix: '≈ 70% stocks / 30% bonds', rate: 0.06 },
+  veryHigh: { label: 'Very-high',     mix: '100% stocks',              rate: 0.07 }
+};
+
+console.debug('[riskOptions] loaded', RISK_OPTIONS);

--- a/stepPensionRisk.js
+++ b/stepPensionRisk.js
@@ -1,11 +1,8 @@
-export const RISK_OPTIONS = {
-  low:      { label: 'Low risk',      mix: '≈ 30% stocks / 70% bonds', rate: 0.04 },
-  balanced: { label: 'Balanced',      mix: '≈ 50% stocks / 50% bonds', rate: 0.05 },
-  high:     { label: 'High risk',     mix: '≈ 70% stocks / 30% bonds', rate: 0.06 },
-  veryHigh: { label: 'Very-high',     mix: '100% stocks',              rate: 0.07 }
-};
+import { RISK_OPTIONS } from './riskOptions.js';
+console.debug('[stepPensionRisk] options', RISK_OPTIONS);
 
 export function renderStepPensionRisk(container, store, setStore, nextBtn){
+  console.debug('[stepPensionRisk] renderStepPensionRisk called');
   container.innerHTML = '';
   // Keep the existing step text above this container; we’re only injecting the cards below it.
   const grid = document.createElement('div');
@@ -24,8 +21,10 @@ export function renderStepPensionRisk(container, store, setStore, nextBtn){
     setStore?.({ pensionRisk: opt.label, pensionRiskKey: key, pensionGrowthRate: opt.rate });
     try{
       localStorage.setItem('fm.pensionRiskKey', key);
+      localStorage.setItem('fm.pensionRiskLabel', opt.label);
       localStorage.setItem('fm.pensionGrowthRate', String(opt.rate));
     }catch(e){}
+    console.debug('[stepPensionRisk] selected', key, opt);
     grid.querySelectorAll('.risk-card').forEach(c=>{
       c.classList.toggle('selected', c.dataset.key===key);
       c.setAttribute('aria-checked', c.dataset.key===key ? 'true' : 'false');


### PR DESCRIPTION
## Summary
- move `RISK_OPTIONS` to standalone `riskOptions.js`
- log risk option diagnostics and step rendering
- load stored pension risk label without importing options

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check riskOptions.js`
- `node --check stepPensionRisk.js`
- `node --check fullMontyWizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a389eba8a88333b5eb89d6e4388f93