### PR TITLE
feat: add compliance notices for projection

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/inputs.css">
+  <link rel="stylesheet" href="styles/results.css">
   <style>
     :root{
       --accent:#c000ff;
@@ -650,6 +651,7 @@
             </div>
           </div>
         </div>
+        <section id="compliance-notices" aria-label="Notices & limits" class="notices-section"></section>
       </section>
 
       <!-- ===== DURING RETIREMENT ===== -->
@@ -717,6 +719,7 @@
       <section id="maxTableSection" class="max-table-section" aria-live="polite">
         <!-- JS will inject a heading + table OR a helpful message -->
       </section>
+      <div id="calcWarnings" style="display:none;"></div>
     </div>
 
   </section>

--- a/pension-projection.html
+++ b/pension-projection.html
@@ -6,8 +6,7 @@
   <title>Pension Growth Projection</title>
  <link rel="icon" type="image/png" href="favicon.png" />
  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles/inputs.css">
-  <link rel="stylesheet" href="styles/results.css">
+  <link rel="stylesheet" href="styles/inputs.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.js"></script>
 
   <style>
@@ -298,8 +297,6 @@
           <canvas id="contribChart"></canvas>
         </div>
       </div>
-
-      <section id="compliance-notices" aria-label="Notices & limits" class="notices-section"></section>
 
       <div id="postCalcContent" style="display:none;">
         <button id="downloadPdf" style="margin-top:1rem">Download PDF report</button>


### PR DESCRIPTION
## Summary
- add mount and stylesheet for compliance notice pills
- render age and SFT notices as interactive pills with detail cards
- keep hidden warning blocks for PDF extraction

## Testing
- `node --check pensionProjectionPage.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c9dc35c83338e288713832ead3a