### PR TITLE
fix: show risk cards on iOS

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -22,13 +22,13 @@
       --shadow-sm:0 2px 4px rgba(0,0,0,.2);
     }
     *{box-sizing:border-box}
-    body{font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh;padding:1rem;margin:0;}
+    body{font-family:'Inter',sans-serif;background:#1a1a1a;color:#fff;display:flex;justify-content:center;align-items:center;min-height:100dvh;min-height:calc(var(--vh,1vh)*100);min-height:-webkit-fill-available;padding:1rem;margin:0;}
     body.modal-open{overflow:hidden;}
     button{padding:.5rem .9rem;font-weight:700;font-size:1rem;border:none;border-radius:8px;cursor:pointer;color:#fff;background:#555;margin:.3rem 0;min-height:2.5rem;}
     .fm-wizard.modal{display:none;}
     .fm-wizard.modal.is-open{position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,.5);display:flex;align-items:stretch;justify-content:center;}
-    .fm-sheet{position:relative;width:100%;max-width:720px;margin:0 auto;height:100vh;height:100svh;display:flex;flex-direction:column;background:var(--surface,#1b1b1b);}
-    @supports (height: 100dvh){.fm-sheet{height:100dvh;}}
+    .fm-sheet{position:relative;width:100%;max-width:720px;margin:0 auto;min-height:100dvh;min-height:calc(var(--vh,1vh)*100);min-height:-webkit-fill-available;display:flex;flex-direction:column;background:var(--surface,#1b1b1b);}
+    @supports (height: 100dvh){.fm-sheet{min-height:100dvh;}}
     .fm-sheet,.fm-header,.fm-footer{padding-left:max(16px,env(safe-area-inset-left));padding-right:max(16px,env(safe-area-inset-right));}
     .fm-header{padding-top:max(12px,env(safe-area-inset-top));}
     .fm-footer{padding-bottom:max(12px,env(safe-area-inset-bottom));}
@@ -59,15 +59,27 @@
     input:focus,select:focus{outline:none;border-color:var(--glow);box-shadow:0 0 0 3px rgba(0,255,136,.25);}
     .error{color:var(--error, #ff6b6b);margin-top:.5rem;font-size:.9rem;}
 
+    .final-step,
+    .risk-section{
+      min-height:100dvh;
+      min-height:calc(var(--vh,1vh)*100);
+      min-height:-webkit-fill-available;
+    }
+
     /* Pension risk cards */
     .risk-grid{
       display:grid;
-      grid-template-columns:repeat(2,minmax(0,1fr));
-      gap:1rem;
+      grid-template-columns:repeat(4,minmax(0,1fr));
+      gap:12px;
       margin-top:1rem;
     }
     @media (max-width:640px){
       .risk-grid{grid-template-columns:1fr;}
+      .risk-card{min-height:140px;}
+    }
+    @supports not (gap: 12px){
+      .risk-grid{row-gap:12px;column-gap:0;}
+      .risk-card + .risk-card{margin-top:12px;}
     }
     .risk-card{
       display:flex;
@@ -91,6 +103,27 @@
     .risk-title{font-weight:700;}
     .risk-mix{font-size:.9rem;opacity:.9;}
     .risk-rate{font-size:.85rem;opacity:.8;}
+
+    /* Disable start-hidden animations on iOS */
+    .is-ios .will-fade-in{
+      opacity:1!important;
+      transform:none!important;
+      transition:none!important;
+    }
+
+    @media (max-width:640px){
+      .has-transform-on-desktop{transform:none!important;}
+      .sticky-on-desktop{position:static!important;}
+    }
+
+    .risk-section{position:relative;z-index:2;}
+    @media (max-width:640px){
+      .cta-bar, .sticky-footer, .wizard{z-index:1;}
+      .cta-bar.is-transparent-over-content{pointer-events:none;}
+    }
+
+    .is-ios .maybe-contents{display:block!important;}
+    .is-ios .glass-bg{-webkit-backdrop-filter:none!important;backdrop-filter:none!important;}
 
     /* Optional: row grouping look */
     .list-wrap .asset-row{
@@ -548,11 +581,13 @@
       pointer-events: none;
     }
   </style>
+  <script src="ios-flag.js"></script>
+  <script src="vh-fix.js"></script>
 </head>
 <body>
   <div id="fullMontyModal" class="fm-wizard modal" role="dialog" aria-modal="true">
     <div class="fm-sheet">
-      <header class="fm-header">
+      <header class="fm-header sticky-on-desktop">
         <div class="fm-step-title" id="fmProgress"></div>
         <div class="fm-progress">
           <div id="fmProgressBar"><div id="fmProgressFill"></div></div>
@@ -562,10 +597,10 @@
       </header>
 
       <main class="fm-body" id="fmBody" tabindex="-1">
-        <div id="fmStepContainer"></div>
+        <div id="fmStepContainer" class="has-transform-on-desktop"></div>
       </main>
 
-      <footer class="fm-footer">
+      <footer class="fm-footer sticky-on-desktop">
         <button class="btn-secondary fm-back" id="fmBack">Back</button>
         <button class="btn-primary fm-next" id="fmNext">Next</button>
       </footer>

--- a/ios-flag.js
+++ b/ios-flag.js
@@ -1,0 +1,6 @@
+(function(){
+  const ua = navigator.userAgent;
+  const isIOS = /iP(hone|od|ad)/.test(ua);
+  const isWebKit = /WebKit/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
+  if (isIOS && isWebKit) document.documentElement.classList.add('is-ios');
+})();

--- a/risk-cards-mount.js
+++ b/risk-cards-mount.js
@@ -1,0 +1,19 @@
+export function mountRiskCards(){
+  // existing render...
+  const cards = document.querySelectorAll('.risk-card');
+
+  // If IntersectionObserver missing or iOS Safari, reveal immediately
+  const isIOS = document.documentElement.classList.contains('is-ios');
+  if (!('IntersectionObserver' in window) || isIOS){
+    cards.forEach(el => el.classList.add('in'));
+    return;
+  }
+
+  // Existing IO logic (keep thresholds lenient)
+  const io = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{
+      if (e.isIntersecting) e.target.classList.add('in');
+    });
+  }, { rootMargin: '150px 0px', threshold: 0.01 });
+  cards.forEach(el => io.observe(el));
+}

--- a/stepPensionRisk.js
+++ b/stepPensionRisk.js
@@ -1,9 +1,11 @@
 import { RISK_OPTIONS } from './riskOptions.js';
+import { mountRiskCards } from './risk-cards-mount.js';
 console.debug('[stepPensionRisk] options', RISK_OPTIONS);
 
 export function renderStepPensionRisk(container, store, setStore, nextBtn){
   console.debug('[stepPensionRisk] renderStepPensionRisk called');
   container.innerHTML = '';
+  container.classList.add('risk-section');
   // Keep the existing step text above this container; we’re only injecting the cards below it.
   const grid = document.createElement('div');
   grid.className = 'risk-grid';
@@ -60,6 +62,9 @@ export function renderStepPensionRisk(container, store, setStore, nextBtn){
 
   container.appendChild(grid);
   container.appendChild(error);
+
+  // Reveal cards when ready
+  mountRiskCards();
 
   // Hook a per-step validator the wizard can call before advancing
   renderStepPensionRisk.validate = () => {

--- a/vh-fix.js
+++ b/vh-fix.js
@@ -1,0 +1,8 @@
+(function setVhVar(){
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+})();
+window.addEventListener('resize', ()=>{
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+});


### PR DESCRIPTION
## Summary
- add iOS and viewport-size detection for Safari
- adjust risk card grid and reveal logic for mobile compatibility
- mitigate sticky/overlay conflicts on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3956baeac8333a6c819a6a93cd5b8