### PR TITLE
Move compliance notices under post-retirement charts

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -690,7 +690,6 @@
             </div>
           </div>
         </div>
-        <section id="compliance-notices" aria-label="Notices & limits" class="notices-section"></section>
       </section>
 
       <!-- ===== DURING RETIREMENT ===== -->
@@ -753,6 +752,8 @@
           </div>
         </div>
       </section>
+
+      <section id="compliance-notices" aria-label="Important notices" class="notices-section"></section>
 
       <!-- Max table section (bottom of page) -->
       <section id="maxTableSection" class="max-table-section" aria-live="polite">

--- a/styles/results.css
+++ b/styles/results.css
@@ -4,41 +4,23 @@
   --danger:#ff5c5c;
 }
 
-/* Hide legacy warning blocks on screen, keep for PDF scraping */
+/* Legacy warning blocks: keep for PDF scraping, hide on-screen */
 #calcWarnings .warning-block{ display:none; }
 
-/* Section and layout */
-.notices-section{ margin-top:14px; display:grid; gap:10px; }
-.notice-pills{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-  gap:8px;
-}
-.notice-pill{
-  display:flex; align-items:center; gap:8px;
-  padding:10px 12px; border-radius:999px;
-  background:#232323; border:1px solid rgba(255,255,255,.08);
-  line-height:1.15; cursor:pointer;
-  transition: box-shadow .2s ease, border-color .2s ease, transform .1s ease;
-}
-.notice-pill:hover{ transform: translateY(-1px); }
-.notice-pill svg{ width:18px; height:18px; flex:0 0 18px; }
-.notice-pill .pill-title{ font-weight:700; font-size:.92rem; }
-.notice-pill .pill-sub{ font-size:.85rem; opacity:.85; }
+/* Notices live under the two post-retirement charts */
+.notices-section{ margin-top:16px; display:grid; gap:10px; }
 
-.notice--ok{ border-color: rgba(0,255,136,.35); box-shadow: 0 0 0 2px rgba(0,255,136,.15) inset; }
-.notice--warn{ border-color: #f0c56b; box-shadow: 0 0 0 2px rgba(240,197,107,.18) inset; }
-.notice--danger{ border-color: var(--danger); box-shadow: 0 0 0 2px rgba(255,92,92,.18) inset; }
-
+/* Warnings-only cards (no pills, no buttons) */
 .notice-cards{ display:grid; gap:8px; }
 .notice-card{
-  background:#232323; border:1px solid rgba(255,255,255,.08);
+  background:#232323;
+  border:1px solid rgba(255,255,255,.08);
   border-left:4px solid var(--accent);
-  border-radius:12px; padding:12px 14px;
+  border-radius:12px;
+  padding:12px 14px;
 }
 .notice-card.warn{ border-left-color:#f0c56b; }
 .notice-card.danger{ border-left-color:var(--danger); }
 .notice-card .title{ font-weight:800; margin-bottom:4px; }
 .notice-card .meta{ font-size:.9rem; opacity:.9; }
-.notice-card .actions{ margin-top:8px; display:flex; gap:8px; flex-wrap:wrap; }
-.notice-card .chip{ padding:6px 10px; border-radius:999px; border:1px solid var(--glow); font-size:.82rem; opacity:.9; }
+.notice-card .actions{ display:none !important; } /* remove any mini-buttons if present */


### PR DESCRIPTION
## Summary
- Render compliance notices after post-retirement charts and keep legacy warning blocks hidden for PDF output
- Simplify notices UI to warnings-only cards with mandatory withdrawals message and updated SFT text
- Ensure PDF extraction includes mandatory withdrawals warning and warnings mount initializes after post-retirement grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a39821a8d483339afa86c8d4c9866a