### PR TITLE
Reveal risk cards immediately on touch-only devices

### DIFF
--- a/risk-cards-mount.js
+++ b/risk-cards-mount.js
@@ -2,6 +2,12 @@ export function mountRiskCards(){
   // existing render...
   const cards = document.querySelectorAll('.risk-card');
 
+  // If on a coarse pointer device with no hover (e.g., touch screens), reveal immediately
+  if (window.matchMedia('(hover: none) and (pointer: coarse)').matches){
+    cards.forEach(el => el.classList.add('in'));
+    return;
+  }
+
   // If IntersectionObserver missing or iOS Safari, reveal immediately
   const isIOS = document.documentElement.classList.contains('is-ios');
   if (!('IntersectionObserver' in window) || isIOS){


### PR DESCRIPTION
## Summary
- Immediately reveal risk cards on touch-only devices by checking `(hover: none) and (pointer: coarse)`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/FinancialPlanning/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a39ac191008333a8d553e21d0dc617