### PR TITLE
Specify IntersectionObserver root

### DIFF
--- a/risk-cards-mount.js
+++ b/risk-cards-mount.js
@@ -14,6 +14,6 @@ export function mountRiskCards(){
     entries.forEach(e=>{
       if (e.isIntersecting) e.target.classList.add('in');
     });
-  }, { rootMargin: '150px 0px', threshold: 0.01 });
+  }, { root: document.querySelector('.fm-body'), rootMargin: '150px 0px', threshold: 0.01 });
   cards.forEach(el => io.observe(el));
 }


### PR DESCRIPTION
## Summary
- ensure risk card animations observe scrolling of `.fm-body` by setting it as the IntersectionObserver root while keeping existing margin and threshold

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check risk-cards-mount.js`


------
https://chatgpt.com/codex/tasks/task_e_68a39acd69dc83339984646a6959a245