### PR TITLE
Revamp pension risk selector

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/inputs.css">
   <link rel="stylesheet" href="styles/results.css">
+  <link rel="stylesheet" href="styles/wizard.css">
   <style>
     :root{
       --accent:#c000ff;
@@ -59,64 +60,13 @@
     input:focus,select:focus{outline:none;border-color:var(--glow);box-shadow:0 0 0 3px rgba(0,255,136,.25);}
     .error{color:var(--error, #ff6b6b);margin-top:.5rem;font-size:.9rem;}
 
-    .final-step,
-    .risk-section{
+    .final-step{
       min-width:0;
       min-height:0;
       min-height:100dvh;
       min-height:calc(var(--vh,1vh)*100);
       min-height:-webkit-fill-available;
     }
-
-    /* Pension risk cards */
-    .risk-grid{
-      display:grid;
-      grid-template-columns:repeat(4,minmax(0,1fr));
-      gap:12px;
-      margin-top:1rem;
-      min-width:0;
-      min-height:0;
-    }
-    @media (max-width:640px){
-      .final-step,
-      .risk-section,
-      .risk-grid{
-        min-width:0;
-        min-height:0;
-      }
-      .risk-grid{
-        display:grid;
-        grid-template-columns:1fr;
-      }
-      .risk-card{min-height:140px;}
-    }
-    @supports not (gap: 12px){
-      .risk-grid{row-gap:12px;column-gap:0;}
-      .risk-card + .risk-card{margin-top:12px;}
-    }
-    .risk-card{
-      display:flex;
-      flex-direction:column;
-      align-items:flex-start;
-      gap:.25rem;
-      padding:1rem;
-      border:1px solid var(--field-border,rgba(255,255,255,.12));
-      border-radius:12px;
-      background:var(--field-bg,rgba(255,255,255,.04));
-      outline:none;
-      cursor:pointer;
-      transition:transform .08s ease, box-shadow .2s ease, border-color .2s ease;
-    }
-    .risk-card:hover{transform:translateY(-1px);}
-    .risk-card:focus{box-shadow:var(--focus-ring,0 0 0 3px rgba(0,255,136,.25));}
-    .risk-card.selected{
-      border-color:var(--focus,#00ff88);
-      box-shadow:var(--focus-ring,0 0 0 3px rgba(0,255,136,.25));
-    }
-    .risk-title{font-weight:700;}
-    .risk-mix{font-size:.9rem;opacity:.9;}
-    .risk-rate{font-size:.85rem;opacity:.8;}
-
     /* Disable start-hidden animations on iOS */
     .is-ios .will-fade-in{
       opacity:1!important;
@@ -129,7 +79,6 @@
       .sticky-on-desktop{position:static!important;}
     }
 
-    .risk-section{position:relative;z-index:2;}
     @media (max-width:640px){
       .cta-bar, .sticky-footer, .wizard{z-index:1;}
       .cta-bar.is-transparent-over-content{pointer-events:none;}

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -5,7 +5,7 @@
 
 import { animate, addKeyboardNav } from './wizardCore.js';
 import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
-import { renderStepPensionRisk } from './stepPensionRisk.js';
+import { renderStepPensionRisk, validateRiskSelection } from './stepPensionRisk.js';
 import { MAX_SALARY_CAP } from './shared/assumptions.js';
 
 // Temporary debug flag: set true to emit fake pension output without engine
@@ -685,7 +685,7 @@ const baseSteps = [
       console.debug('[fullMontyWizard] renderStepPensionRisk Step 6');
       renderStepPensionRisk(sel, fullMontyStore, setStore, btnNext);
     },
-    validate(){ return renderStepPensionRisk.validate(); }
+    validate(){ return (renderStepPensionRisk.validate && renderStepPensionRisk.validate()) || validateRiskSelection(); }
   }
 ];
 

--- a/stepPensionRisk.js
+++ b/stepPensionRisk.js
@@ -1,96 +1,187 @@
-import { RISK_OPTIONS } from './riskOptions.js';
-import { mountRiskCards } from './risk-cards-mount.js';
-console.debug('[stepPensionRisk] options', RISK_OPTIONS);
+// stepPensionRisk.js
+// A11y-first radio-card selector with slick mobile/desktop UX.
+// Keeps your existing API + localStorage keys.
 
-// Temporary debug flag; set to false to disable layout logs
-const DEBUG_PENSION_RISK = true;
+const RISK_OPTIONS = {
+  low: {
+    label: 'Low risk',
+    mix: '≈ 30% stocks / 70% bonds',
+    rate: 0.04,
+    level: 2, // fills 2/5 on the meter
+    blurb: 'Lower volatility; slower expected growth.'
+  },
+  balanced: {
+    label: 'Balanced',
+    mix: '≈ 50% stocks / 50% bonds',
+    rate: 0.05,
+    level: 3,
+    blurb: 'Balanced mix of growth and stability.'
+  },
+  high: {
+    label: 'High risk',
+    mix: '≈ 70% stocks / 30% bonds',
+    rate: 0.06,
+    level: 4,
+    blurb: 'Higher expected growth with larger swings.'
+  },
+  veryHigh: {
+    label: 'Very-high',
+    mix: '100% stocks',
+    rate: 0.07,
+    level: 5,
+    blurb: 'Maximum growth potential; highest volatility.'
+  }
+};
+
+function pct(n){ return (n * 100).toFixed(0) + '%'; }
 
 export function renderStepPensionRisk(container, store, setStore, nextBtn){
-  console.debug('[stepPensionRisk] renderStepPensionRisk called');
+  const AUTO_ADVANCE = false; // set true if you want to auto-advance after a pick
+  const savedKey  = store?.pensionRiskKey || localStorage.getItem('fm.pensionRiskKey');
+  const hasSaved  = savedKey && RISK_OPTIONS[savedKey];
+
   container.innerHTML = '';
-  container.classList.add('risk-section');
-  // Keep the existing step text above this container; we’re only injecting the cards below it.
+
+  // —— Wrapper
+  const wrap = document.createElement('div');
+  wrap.className = 'risk-step';
+
+  // —— Header / helper
+  const head = document.createElement('div');
+  head.className = 'risk-head';
+  head.innerHTML = `
+    <h3 class="risk-title">Choose your pension growth profile</h3>
+    <p class="risk-sub">
+      This sets a long-term growth assumption for projections (not a guarantee).
+      You can change it later.
+    </p>
+  `;
+  wrap.appendChild(head);
+
+  // —— Cards (radiogroup)
   const grid = document.createElement('div');
   grid.className = 'risk-grid';
-  grid.setAttribute('role','radiogroup');
+  grid.setAttribute('role', 'radiogroup');
+  grid.setAttribute('aria-label', 'Select a pension risk profile');
 
-  const error = document.createElement('div');
-  error.className = 'error';
-  error.style.display = 'none';
-
-  let selectedKey = store?.pensionRiskKey || localStorage.getItem('fm.pensionRiskKey') || null;
-
-  function select(key){
-    selectedKey = key;
-    const opt = RISK_OPTIONS[key];
-    setStore?.({ pensionRisk: opt.label, pensionRiskKey: key, pensionGrowthRate: opt.rate });
-    try{
-      localStorage.setItem('fm.pensionRiskKey', key);
-      localStorage.setItem('fm.pensionRiskLabel', opt.label);
-      localStorage.setItem('fm.pensionGrowthRate', String(opt.rate));
-    }catch(e){}
-    console.debug('[stepPensionRisk] selected', key, opt);
-    grid.querySelectorAll('.risk-card').forEach(c=>{
-      c.classList.toggle('selected', c.dataset.key===key);
-      c.setAttribute('aria-checked', c.dataset.key===key ? 'true' : 'false');
-    });
-    if(nextBtn) nextBtn.disabled = false;
-    error.style.display = 'none';
-  }
-
-  Object.entries(RISK_OPTIONS).forEach(([key,opt])=>{
+  // roving tabindex helpers
+  const createCard = (key, opt, isFirst) => {
     const card = document.createElement('button');
     card.type = 'button';
     card.className = 'risk-card';
     card.dataset.key = key;
-    card.setAttribute('role','radio');
+    card.setAttribute('role', 'radio');
     card.setAttribute('aria-checked', 'false');
-    card.innerHTML =
-      `<span class="risk-title">${opt.label}</span>`+
-      `<span class="risk-mix">${opt.mix}</span>`+
-      `<span class="risk-rate">≈ ${(opt.rate*100).toFixed(0)}% p.a.</span>`;
-    card.addEventListener('click', ()=>select(key));
-    card.addEventListener('keydown', e=>{
+    card.tabIndex = isFirst ? 0 : -1;
+    card.innerHTML = `
+      <div class="rc-head">
+        <div class="rc-label">${opt.label}</div>
+        <div class="rc-mix">${opt.mix}</div>
+      </div>
+      <div class="rc-body">
+        <div class="rc-rate">
+          <span class="rc-rate-num">${pct(opt.rate)}</span>
+          <span class="rc-rate-sub">assumed annual growth</span>
+        </div>
+        <div class="rc-meter" aria-hidden="true" data-level="${opt.level}">
+          <i></i><i></i><i></i><i></i><i></i>
+        </div>
+        <p class="rc-blurb">${opt.blurb}</p>
+      </div>
+      <div class="rc-cta" aria-hidden="true">Select</div>
+    `;
+
+    // Press ripple / tactile feedback (simple)
+    card.addEventListener('pointerdown', () => card.classList.add('pressed'));
+    card.addEventListener('pointerup',   () => card.classList.remove('pressed'));
+    card.addEventListener('pointercancel', () => card.classList.remove('pressed'));
+    card.addEventListener('pointerleave',  () => card.classList.remove('pressed'));
+
+    // Selection
+    card.addEventListener('click', () => select(key, true));
+
+    // Keyboard: Space/Enter select; arrows move focus
+    card.addEventListener('keydown', (e) => {
       const cards = Array.from(grid.querySelectorAll('.risk-card'));
-      let idx = cards.indexOf(card);
-      if(['ArrowRight','ArrowDown'].includes(e.key)){ idx = (idx+1)%cards.length; cards[idx].focus(); e.preventDefault(); }
-      if(['ArrowLeft','ArrowUp'].includes(e.key)){ idx = (idx-1+cards.length)%cards.length; cards[idx].focus(); e.preventDefault(); }
-      if(['Enter',' '].includes(e.key)){ select(key); e.preventDefault(); }
+      const idx = cards.indexOf(card);
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        select(key, true);
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = cards[(idx + 1) % cards.length];
+        next.focus();
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = cards[(idx - 1 + cards.length) % cards.length];
+        prev.focus();
+      }
     });
-    grid.appendChild(card);
+
+    return card;
+  };
+
+  Object.entries(RISK_OPTIONS).forEach(([key, opt], i) => {
+    grid.appendChild(createCard(key, opt, i === 0));
   });
 
-  if(selectedKey){ select(selectedKey); }
-  else if(nextBtn) { nextBtn.disabled = true; }
+  wrap.appendChild(grid);
 
-  container.appendChild(grid);
-  if(DEBUG_PENSION_RISK){
-    console.debug('[stepPensionRisk] ua/dimensions', navigator.userAgent, window.innerWidth, window.innerHeight);
-  }
-  container.appendChild(error);
+  // —— Footer / note
+  const foot = document.createElement('div');
+  foot.className = 'risk-foot';
+  foot.innerHTML = `
+    <div class="risk-note">
+      <strong>Note:</strong> These rates are planning assumptions for illustration.
+      Real-world returns vary and can be negative in some years.
+    </div>
+  `;
+  wrap.appendChild(foot);
 
-  // Reveal cards when ready
-  mountRiskCards();
+  container.appendChild(wrap);
 
-  if(DEBUG_PENSION_RISK && window.matchMedia('(hover: none) and (pointer: coarse)').matches){
-    const firstCard = grid.querySelector('.risk-card');
-    if(firstCard){
-      const styles = getComputedStyle(firstCard);
-      const styleDump = {};
-      for(const prop of styles){
-        styleDump[prop] = styles.getPropertyValue(prop);
-      }
-      console.debug('[stepPensionRisk] first risk-card styles', styleDump);
+  // Initial state
+  if (nextBtn) nextBtn.disabled = !hasSaved;
+  if (hasSaved) select(savedKey, false);
+
+  function select(key, userInitiated){
+    // Visually mark
+    grid.querySelectorAll('.risk-card').forEach((c) => {
+      const isSel = c.dataset.key === key;
+      c.classList.toggle('selected', isSel);
+      c.setAttribute('aria-checked', String(isSel));
+      c.tabIndex = isSel ? 0 : -1;
+    });
+
+    // Persist + push to store
+    const sel = RISK_OPTIONS[key];
+    setStore({
+      pensionRisk: sel.label,
+      pensionRiskKey: key,
+      pensionGrowthRate: sel.rate
+    });
+    localStorage.setItem('fm.pensionRiskKey', key);
+    localStorage.setItem('fm.pensionRiskLabel', sel.label);
+    localStorage.setItem('fm.pensionGrowthRate', String(sel.rate));
+
+    if (nextBtn) nextBtn.disabled = false;
+    if (AUTO_ADVANCE && userInitiated && nextBtn) {
+      // brief affordance before moving on
+      setTimeout(() => nextBtn.click(), 140);
     }
   }
-
-  // Hook a per-step validator the wizard can call before advancing
-  renderStepPensionRisk.validate = () => {
-    const ok = !!selectedKey;
-    if(!ok){
-      error.textContent = 'Please select a growth profile to continue.';
-      error.style.display = 'block';
-    }
-    return { ok, errors:{} };
-  };
 }
+
+export function validateRiskSelection(){
+  const key = localStorage.getItem('fm.pensionRiskKey');
+  const rate = parseFloat(localStorage.getItem('fm.pensionGrowthRate'));
+  const ok = !!key && Number.isFinite(rate);
+  return ok ? { ok: true } : { ok: false, message: 'Please choose a risk profile.' };
+}
+
+// Keep compatibility with your wizard:
+export const renderStepPensionRiskValidate = validateRiskSelection;
+export const validate = validateRiskSelection;
+export default { renderStepPensionRisk, validateRiskSelection };
+renderStepPensionRisk.validate = validateRiskSelection;
+

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -1,0 +1,150 @@
+/* Risk step layout */
+.risk-step{
+  display: grid;
+  gap: 16px;
+}
+
+.risk-head{
+  display: grid;
+  gap: 6px;
+}
+.risk-title{
+  font-size: 1.1rem;
+  font-weight: 800;
+  letter-spacing: .2px;
+}
+.risk-sub{
+  color: #bbb;
+  line-height: 1.4;
+}
+
+/* Grid that fills space nicely on desktop, stacks on mobile */
+.risk-grid{
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 680px){
+  .risk-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1040px){
+  .risk-grid{ grid-template-columns: repeat(4, 1fr); }
+}
+
+/* Card (radio) */
+.risk-card{
+  -webkit-tap-highlight-color: transparent;
+  background: #232323;
+  color: #fff;
+  text-align: left;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 14px;
+  padding: 14px;
+  min-height: 168px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 10px;
+  cursor: pointer;
+  outline: none;
+  position: relative;
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease, background .15s ease;
+}
+.risk-card:hover{
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0,0,0,.35);
+}
+.risk-card.pressed{ transform: scale(.985); }
+
+.risk-card:focus-visible{
+  border-color: #00ff88;
+  box-shadow: 0 0 0 3px rgba(0,255,136,.25);
+}
+
+.risk-card.selected{
+  border-color: rgba(0,255,136,.8);
+  background: linear-gradient(180deg, rgba(0,255,136,.12), rgba(0,0,0,0));
+}
+
+/* Head */
+.rc-head{ display: grid; gap: 4px; }
+.rc-label{ font-weight: 800; letter-spacing: .2px; }
+.rc-mix{ color:#bbb; font-size:.92rem; }
+
+/* Body */
+.rc-body{
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+/* Big rate */
+.rc-rate{
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.rc-rate-num{
+  font-size: 1.8rem;
+  font-weight: 900;
+  line-height: 1;
+}
+.rc-rate-sub{
+  color:#bbb; font-size:.9rem;
+}
+
+/* 5-dot meter */
+.rc-meter{
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 6px;
+}
+.rc-meter i{
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.16);
+  display: inline-block;
+  transition: background .15s ease, transform .15s ease;
+}
+.risk-card:hover .rc-meter i{ transform: translateY(-1px); }
+
+/* fill according to data-level (1–5) */
+.rc-meter[data-level="1"] i:nth-child(-n+1),
+.rc-meter[data-level="2"] i:nth-child(-n+2),
+.rc-meter[data-level="3"] i:nth-child(-n+3),
+.rc-meter[data-level="4"] i:nth-child(-n+4),
+.rc-meter[data-level="5"] i:nth-child(-n+5){
+  background: #00ff88;
+}
+
+/* Blurb */
+.rc-blurb{ color:#cfcfcf; font-size:.95rem; line-height:1.35; }
+
+/* Call to action hint (desktop hover) */
+.rc-cta{
+  align-self: end;
+  color:#88ffcc;
+  opacity:.0;
+  font-weight:700;
+  letter-spacing:.3px;
+  transition: opacity .15s ease, transform .15s ease;
+}
+.risk-card:hover .rc-cta{ opacity:1; transform: translateY(-2px); }
+
+/* Footer note */
+.risk-foot{ margin-top: 2px; }
+.risk-note{
+  color:#bbb;
+  font-size:.92rem;
+  border-left: 3px solid rgba(255,255,255,.14);
+  padding: 8px 10px;
+  background: rgba(255,255,255,.04);
+  border-radius: 8px;
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .risk-card{ transition: none; }
+  .risk-card:hover{ transform:none; box-shadow:none; }
+  .rc-meter i{ transition: none; }
+}
+


### PR DESCRIPTION
## Summary
- Replace pension risk step with accessible radio-card component that stores selection and validates input
- Add dedicated wizard styles and hook new risk step into Full Monty wizard
- Link new styling in full-monty.html and clean up legacy CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed7b12d483339372746748358a57