### PR TITLE
Polish pension risk step and restore dot meter

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -9,7 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/inputs.css">
   <link rel="stylesheet" href="styles/results.css">
-  <link rel="stylesheet" href="styles/wizard.css">
+  <link rel="stylesheet" href="styles/wizard.css"> <!-- must be last -->
   <style>
     :root{
       --accent:#c000ff;

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -5,7 +5,7 @@
 
 import { animate, addKeyboardNav } from './wizardCore.js';
 import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
-import { renderStepPensionRisk, validateRiskSelection } from './stepPensionRisk.js';
+import { renderStepPensionRisk } from './stepPensionRisk.js';
 import { MAX_SALARY_CAP } from './shared/assumptions.js';
 
 // Temporary debug flag: set true to emit fake pension output without engine
@@ -685,7 +685,9 @@ const baseSteps = [
       console.debug('[fullMontyWizard] renderStepPensionRisk Step 6');
       renderStepPensionRisk(sel, fullMontyStore, setStore, btnNext);
     },
-    validate(){ return (renderStepPensionRisk.validate && renderStepPensionRisk.validate()) || validateRiskSelection(); }
+    validate(){
+      return (renderStepPensionRisk.validate && renderStepPensionRisk.validate()) || { ok:false, message:'Please choose a risk profile.' };
+    }
   }
 ];
 

--- a/stepPensionRisk.js
+++ b/stepPensionRisk.js
@@ -84,7 +84,7 @@ export function renderStepPensionRisk(container, store, setStore, nextBtn){
           <span class="rc-rate-sub">assumed annual growth</span>
         </div>
         <div class="rc-meter" aria-hidden="true" data-level="${opt.level}">
-          <i></i><i></i><i></i><i></i><i></i>
+          <span></span><span></span><span></span><span></span><span></span>
         </div>
         <p class="rc-blurb">${opt.blurb}</p>
       </div>
@@ -179,9 +179,7 @@ export function validateRiskSelection(){
   return ok ? { ok: true } : { ok: false, message: 'Please choose a risk profile.' };
 }
 
-// Keep compatibility with your wizard:
-export const renderStepPensionRiskValidate = validateRiskSelection;
-export const validate = validateRiskSelection;
-export default { renderStepPensionRisk, validateRiskSelection };
 renderStepPensionRisk.validate = validateRiskSelection;
+export { validateRiskSelection as validate };
+export default { renderStepPensionRisk, validateRiskSelection };
 

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -148,3 +148,121 @@
   .rc-meter i{ transition: none; }
 }
 
+/* === Risk Step: hardened selectors + desktop polish (append at end) === */
+.risk-step{ display:grid; gap:16px; }
+
+.risk-step .risk-grid{
+  display:grid;
+  gap:12px;
+  grid-template-columns:1fr;
+}
+@media (min-width: 680px){
+  .risk-step .risk-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1040px){
+  .risk-step .risk-grid{ grid-template-columns: repeat(4, 1fr); }
+}
+
+.risk-step .risk-card{
+  -webkit-tap-highlight-color: transparent;
+  background:#232323;
+  color:#fff;
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:14px;
+  padding:14px;
+  min-height:168px;
+  display:grid;
+  grid-template-rows:auto 1fr auto;
+  gap:10px;
+  cursor:pointer;
+  outline:none;
+  transition:transform .15s ease, box-shadow .15s ease, border-color .15s ease, background .15s ease;
+}
+@media (hover:hover){
+  .risk-step .risk-card:hover{
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0,0,0,.35);
+  }
+}
+.risk-step .risk-card.pressed{ transform: scale(.985); }
+.risk-step .risk-card:focus-visible{
+  border-color:#00ff88;
+  box-shadow:0 0 0 3px rgba(0,255,136,.25);
+}
+.risk-step .risk-card.selected{
+  border-color:rgba(0,255,136,.8);
+  background:linear-gradient(180deg, rgba(0,255,136,.12), rgba(0,0,0,0));
+}
+
+.risk-step .rc-head{ display:grid; gap:4px; }
+.risk-step .rc-label{ font-weight:800; letter-spacing:.2px; }
+.risk-step .rc-mix{ color:#bbb; font-size:.92rem; }
+.risk-step .rc-body{ display:grid; align-content:start; gap:10px; }
+
+.risk-step .rc-rate{ display:flex; align-items:baseline; gap:8px; }
+.risk-step .rc-rate-num{ font-size:1.8rem; font-weight:900; line-height:1; }
+.risk-step .rc-rate-sub{ color:#bbb; font-size:.9rem; }
+
+/* Dot meter (using span, strong specificity) */
+.risk-step .rc-meter{
+  display:inline-grid;
+  grid-auto-flow:column;
+  gap:6px;
+  align-items:center;
+}
+.risk-step .rc-meter span{
+  width:12px; height:12px;
+  display:block;
+  border-radius:50%;
+  background: rgba(255,255,255,.16);
+  transition: background .15s ease, transform .15s ease;
+}
+@media (hover:hover){
+  .risk-step .risk-card:hover .rc-meter span{ transform: translateY(-1px); }
+}
+/* Fill by level (1–5) */
+.risk-step .rc-meter[data-level="1"] span:nth-child(-n+1),
+.risk-step .rc-meter[data-level="2"] span:nth-child(-n+2),
+.risk-step .rc-meter[data-level="3"] span:nth-child(-n+3),
+.risk-step .rc-meter[data-level="4"] span:nth-child(-n+4),
+.risk-step .rc-meter[data-level="5"] span:nth-child(-n+5){
+  background:#00ff88;
+}
+
+/* CTA hint */
+.risk-step .rc-cta{
+  align-self:end;
+  color:#88ffcc;
+  opacity:0;
+  font-weight:700;
+  letter-spacing:.3px;
+  transition: opacity .15s ease, transform .15s ease;
+}
+@media (hover:hover){
+  .risk-step .risk-card:hover .rc-cta{ opacity:1; transform: translateY(-2px); }
+}
+
+/* Footer note */
+.risk-step .risk-note{
+  color:#bbb;
+  font-size:.92rem;
+  border-left:3px solid rgba(255,255,255,.14);
+  padding:8px 10px;
+  background: rgba(255,255,255,.04);
+  border-radius:8px;
+}
+
+/* Desktop scale tweaks */
+@media (min-width: 1040px){
+  .risk-step .risk-card{ padding:18px; min-height:210px; }
+  .risk-step .rc-rate-num{ font-size:2.1rem; }
+  .risk-step .rc-meter span{ width:14px; height:14px; }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .risk-step .risk-card{ transition:none; }
+  .risk-step .risk-card:hover{ transform:none; box-shadow:none; }
+  .risk-step .rc-meter span{ transition:none; }
+}
+


### PR DESCRIPTION
## Summary
- Replace icon-based risk meter with span elements and export validation hook for reuse
- Append hardened, desktop-friendly risk step styles and ensure wizard stylesheet loads last
- Update Full Monty wizard to use risk step validator

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2d04b888333a516cceee5f34e1f