### PR TITLE
Refine mobile layout for Full Monty results

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -569,7 +569,8 @@
     </div>
   </div>
   <section id="fullMontyResults" class="fm-results">
-    <div class="results-shell">
+    <main id="fm-results" class="fm-results-root">
+      <div class="results-shell">
       <!-- Top Summary / Actions row -->
       <div id="resultsSummary" class="summary-row" aria-live="polite"></div>
 
@@ -584,29 +585,29 @@
           </span>
         </label>
         <div id="maxToggleNote" class="toggle-note" aria-live="polite"></div>
-        <button id="editInputsBtn" class="btn-primary small fab-edit" aria-label="Edit inputs">
-          Edit inputs
-        </button>
+        <button id="editInputsBtn" class="fab-edit-inputs" type="button">Edit inputs</button>
       </div>
 
       <!-- ===== BEFORE RETIREMENT ===== -->
       <section class="results-phase" id="phase-pre">
-        <div class="phase-head">
-          <div>
-            <h2 class="phase-title">Before retirement — Building your pension</h2>
-            <p class="phase-subline">
+        <header class="fm-section-head">
+          <div class="fm-section-title">
+            <h2>Before retirement —</h2>
+            <h3>Building your pension</h3>
+            <p class="fm-section-sub">
               From today to retirement, see how your pension grows and what drives it (your contributions vs. investment growth).
             </p>
           </div>
-          <div class="phase-chips">
-            <span class="chip">Now → Age <strong id="chipRetAgeA">65</strong></span>
-            <span class="chip" id="chipAssumptionWrap">Assumption: <strong id="chipAssumption">Current contributions</strong></span>
+
+          <div class="fm-section-tools">
+            <span class="range-badge">Now → Age <strong id="chipRetAgeA">65</strong></span>
+            <span class="assumption-chip" id="chipAssumptionWrap"><strong>Assumption:</strong> <span id="chipAssumption">Current contributions</span></span>
           </div>
-        </div>
+        </header>
 
         <div class="phase-grid">
           <!-- MOVE your existing Projected Pension Value block here -->
-          <div class="chart-wrapper" id="chart-pension-value">
+          <div class="chart-wrapper chart-card" id="chart-pension-value">
             <div class="chart-header">
               <h3 class="chart-headline">Will my pension reach my Financial Freedom Target?</h3>
               <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
@@ -633,7 +634,7 @@
           </div>
 
           <!-- MOVE your existing Annual Contributions & Investment Growth block here -->
-          <div class="chart-wrapper" id="chart-annual-contrib">
+          <div class="chart-wrapper chart-card" id="chart-annual-contrib">
             <div class="chart-header">
               <h3 class="chart-headline">How much comes from me vs. my money working for me?</h3>
               <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
@@ -656,21 +657,23 @@
 
       <!-- ===== DURING RETIREMENT ===== -->
       <section class="results-phase" id="phase-post">
-        <div class="phase-head">
-          <div>
-            <h2 class="phase-title">During retirement — Staying funded to age 100</h2>
-            <p class="phase-subline">
+        <header class="fm-section-head">
+          <div class="fm-section-title">
+            <h2>During retirement —</h2>
+            <h3>Staying funded to age 100</h3>
+            <p class="fm-section-sub">
               From retirement to age 100, track your pension balance and yearly income against your inflation-adjusted income requirement.
             </p>
           </div>
-          <div class="phase-chips">
-            <span class="chip">Age <strong id="chipRetAgeB">65</strong> → <strong>100</strong></span>
+
+          <div class="fm-section-tools">
+            <span class="range-badge">Age <strong id="chipRetAgeB">65</strong> → <strong>100</strong></span>
           </div>
-        </div>
+        </header>
 
         <div class="phase-grid">
           <!-- MOVE your existing Projected Balance in Retirement block here -->
-          <div class="chart-wrapper" id="chart-retirement-balance">
+          <div class="chart-wrapper chart-card" id="chart-retirement-balance">
             <div class="chart-header">
               <h3 class="chart-headline">Will my pension last to age 100?</h3>
               <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
@@ -694,7 +697,7 @@
           </div>
 
           <!-- MOVE your existing Annual Retirement Income block here -->
-          <div class="chart-wrapper" id="chart-retirement-income">
+          <div class="chart-wrapper chart-card" id="chart-retirement-income">
             <div class="chart-header">
               <h3 class="chart-headline">Will my income cover my lifestyle in retirement?</h3>
               <span class="info-icon" tabindex="0" aria-label="Chart information">i</span>
@@ -722,7 +725,8 @@
         <!-- JS will inject a heading + table OR a helpful message -->
       </section>
       <div id="calcWarnings" style="display:none;"></div>
-    </div>
+      </div>
+    </main>
 
   </section>
 

--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -287,15 +287,15 @@ function renderKPIs({ projValue, balances }, fyRequired) {
   const root = $('#kpis');
   if (!root) return;
   root.innerHTML = `
-    <div class="kpi-card">
+    <div class="kpi-card metric">
       <div class="kpi-label">Projected pot @ ${ageAtRet}</div>
       <div class="kpi-val">${fmtEuro(projValue)}</div>
     </div>
-    <div class="kpi-card">
+    <div class="kpi-card metric">
       <div class="kpi-label">FY Target</div>
       <div class="kpi-val">${fyRequired ? fmtEuro(fyRequired) : 'No extra pot needed'}</div>
     </div>
-    <div class="kpi-card ${cls}">
+    <div class="kpi-card metric ${cls}">
       <div class="kpi-label">${gap>=0?'Surplus vs FY':'Shortfall vs FY'}</div>
       <div class="kpi-val">${fmtEuro(Math.abs(gap))}</div>
     </div>

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -340,3 +340,124 @@
 }
 .fm-sheet .ic-body::-webkit-scrollbar-thumb:hover,
 .fm-sheet .risk-grid::-webkit-scrollbar-thumb:hover{ background: var(--sb-hover); }
+
+/* --- Full Monty Results Root --- */
+.fm-results-root {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  /* iOS safe areas */
+  padding-left: calc(16px + env(safe-area-inset-left));
+  padding-right: calc(16px + env(safe-area-inset-right));
+}
+
+/* Space out the cards/sections a bit more on mobile */
+@media (max-width: 767px) {
+  .fm-results-root .result-card,
+  .fm-results-root .summary-row,
+  .fm-results-root .metric,
+  .fm-results-root .chart-card {
+    margin-bottom: 14px;
+    border-radius: 12px;
+  }
+}
+
+/* Floating Edit Inputs button */
+.fab-edit-inputs {
+  position: fixed;
+  right: clamp(16px, 2vw, 28px);
+  bottom: max(16px, calc(16px + env(safe-area-inset-bottom)));
+  z-index: 1000;
+  padding: 12px 18px;
+  font-weight: 700;
+  border: none;
+  border-radius: 999px;
+  background: var(--accentA, #00ff66);
+  color: #0b0b0b;
+  box-shadow: 0 8px 20px rgba(0,0,0,.35);
+  cursor: pointer;
+  transition: transform .08s ease, box-shadow .2s ease;
+}
+
+.fab-edit-inputs:active {
+  transform: translateY(1px);
+  box-shadow: 0 6px 16px rgba(0,0,0,.35);
+}
+
+/* Prevent overlap with any bottom nav/toast on very small screens */
+@media (max-width: 374px) {
+  .fab-edit-inputs { bottom: max(12px, calc(12px + env(safe-area-inset-bottom))); }
+}
+
+/* Section head layout */
+.fm-section-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: 12px;
+  margin: 8px 0 10px;
+}
+
+/* Tools area (chips) */
+.fm-section-tools {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: 100%;
+}
+
+.range-badge,
+.assumption-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.06);
+  font-size: .9rem;
+}
+
+/* Green accent ring for the assumption chip to stand out */
+.assumption-chip {
+  border-color: var(--accentA, #00ff66);
+}
+
+/* Stack layout on small screens so the chips don't squash the title */
+@media (max-width: 767px) {
+  .fm-section-head {
+    grid-template-columns: 1fr;
+  }
+  .fm-section-tools {
+    justify-content: flex-start;
+  }
+}
+
+/* Optional: make long titles breathe on mobile */
+@media (max-width: 480px) {
+  .fm-section-title h2,
+  .fm-section-title h3 {
+    line-height: 1.15;
+  }
+}
+
+/* Chart/metric panels keep their own padding so the canvas/labels never hug edges */
+.chart-card,
+.metric,
+.summary-row {
+  padding: 12px 14px;
+  background: var(--panel, #232323);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 12px;
+}
+
+/* Extra breathing room for canvases */
+.chart-card canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 4px 0 0;
+}


### PR DESCRIPTION
## Summary
- Wrap results content in a padded container and add a fixed "Edit inputs" FAB for mobile.
- Rework section headers and chips to stack on small screens while preserving desktop grid.
- Tag charts and KPI cards for consistent card padding and spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d803c954833387d0a7a8f144e5d9