### PR TITLE
Hide edit inputs FAB on wizard pages

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -1,6 +1,7 @@
 // fullMontyResults.js
 import { fyRequiredPot } from './shared/fyRequiredPot.js';
 import { sftForYear, CPI, STATE_PENSION, SP_START, MAX_SALARY_CAP } from './shared/assumptions.js';
+import { setUIMode } from './uiMode.js';
 
 const AGE_BANDS = [
   { max: 29,  pct: 0.15 },
@@ -249,6 +250,7 @@ const $ = (s)=>document.querySelector(s);
 console.debug('[FM Results] loaded');
 
 document.addEventListener('DOMContentLoaded', () => {
+  setUIMode('results');
   const chk = document.querySelector('#maxContribsChk');
   const note = document.querySelector('#maxToggleNote');
   const btn = document.querySelector('#editInputsBtn');

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -7,6 +7,7 @@ import { animate, addKeyboardNav } from './wizardCore.js';
 import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
 import { renderStepPensionRisk } from './stepPensionRisk.js';
 import { MAX_SALARY_CAP } from './shared/assumptions.js';
+import { setUIMode } from './uiMode.js';
 
 // Temporary debug flag: set true to emit fake pension output without engine
 const FM_DEBUG_FAKE_PENSION_OUTPUT = false;
@@ -273,6 +274,7 @@ function closeModal() {
   modal.classList.remove('is-open');
   if (window.__destroyFmWizardUX) window.__destroyFmWizardUX();
   document.body.classList.remove('modal-open');
+  setUIMode('results');
 }
 
 function initFmWizardMobileUX(){
@@ -728,6 +730,7 @@ function yearsFrom(dobStr) {
 // Wizard navigation ------------------------------------------------
 
 function render() {
+  setUIMode('wizard');
   refreshSteps();
   if (cur >= steps.length) cur = steps.length - 1;
   const step = steps[cur];

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -362,6 +362,18 @@
   }
 }
 
+/* --- Edit Inputs FAB visibility control --- */
+.fab-edit-inputs {
+  display: none;                 /* default: hidden everywhere */
+}
+
+/* Show only when body has results mode */
+body.is-results .fab-edit-inputs {
+  display: inline-flex;          /* matches your existing FAB styling */
+}
+
+/* Keep your existing FAB position/style rules below as-is (position: fixed, bottom/right, etc.) */
+
 /* Floating Edit Inputs button */
 .fab-edit-inputs {
   position: fixed;

--- a/uiMode.js
+++ b/uiMode.js
@@ -1,0 +1,14 @@
+export function setUIMode(mode){
+  // mode: 'wizard' | 'results'
+  document.body.classList.toggle('is-results', mode === 'results');
+  document.body.classList.toggle('is-wizard', mode === 'wizard');
+}
+
+export function applyModeFromLocation(){
+  const h = (location.hash || '').toLowerCase();
+  if(h.includes('result')) setUIMode('results');
+  else setUIMode('wizard');
+}
+
+window.addEventListener('hashchange', applyModeFromLocation);
+document.addEventListener('DOMContentLoaded', applyModeFromLocation);


### PR DESCRIPTION
## Summary
- Hide edit inputs floating button by default and show only on results screens
- Track UI mode via body classes with new helper
- Toggle mode when rendering wizard steps or results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da56b1d08333b7d9d358a6a18285