### PR TITLE
feat: restore hero nudge actions

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -82,18 +82,13 @@ function renderHeroNowOrQueue() {
 
   if (typeof window.renderResults === 'function') {
     window.renderResults(mount, payload);
+    window.__pendingHeroPayload = null;
   } else {
     window.__pendingHeroPayload = payload;
   }
 }
 
-window.addEventListener('fm-renderer-ready', () => {
-  if (window.__pendingHeroPayload) {
-    const mount = document.getElementById('resultsView');
-    window.renderResults(mount, window.__pendingHeroPayload);
-    window.__pendingHeroPayload = null;
-  }
-});
+window.addEventListener('fm-renderer-ready', renderHeroNowOrQueue);
 
 function renderComplianceNotices(container){
   container = ensureNoticesMount() || container || document.getElementById('compliance-notices');

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -740,6 +740,12 @@
 }
 
 /* ---------- HERO (shortfall-first) ---------- */
+.hero-prefix{
+  text-align: center;
+  color: var(--text-2, rgba(255,255,255,.72));
+  margin: 0 0 2px 0;
+  font-size: clamp(14px, 3.6vw, 16px);
+}
 .hero-number{
   font-size: clamp(28px, 7vw, 36px);
   font-weight: 800;


### PR DESCRIPTION
## Summary
- style hero prefix copy for the Full Monty results hero
- expose `window.fmApplyNudge` in the wizard to adjust contributions or retirement age and re-run
- update hero renderer and results logic to use pure payloads and nudge callbacks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b426cc29748333b956d73bb1b03958