### PR TITLE
Year-aware SFT notices and pension wording

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -6,7 +6,7 @@
 import { animate, addKeyboardNav } from './wizardCore.js';
 import { currencyInput, percentInput, numFromInput, clampPercent } from './ui-inputs.js';
 import { renderStepPensionRisk } from './stepPensionRisk.js';
-import { MAX_SALARY_CAP } from './shared/assumptions.js';
+import { MAX_SALARY_CAP, sftForYear } from './shared/assumptions.js';
 import { setUIMode } from './uiMode.js';
 
 // Temporary debug flag: set true to emit fake pension output without engine
@@ -911,27 +911,10 @@ function formatEUR(x){
   }catch(e){ return `€${(Number(x)||0).toLocaleString()}`; }
 }
 
-function getSftLimitForYear(year) {
-  // Government path: €2.0m (2025) -> +€200k p.a. -> €2.8m (2029). After 2029, hold €2.8m.
-  if (year <= 2025) return 2000000;
-  if (year >= 2029) return 2800000;
-  return 2000000 + (year - 2025) * 200000; // 2026–2028 linear by +200k
-}
-
-function getEffectiveSftLimit(contextYear, hasPartner) {
-  const base = getSftLimitForYear(contextYear);
-  return hasPartner ? base * 2 : base;
-}
 
 function setHidden(el, hidden) {
   if (!el) return;
   el.hidden = !!hidden;
-}
-
-function scrollToAssumptionSft() {
-  const el = document.getElementById('assumption-sft');
-  if (!el) return;
-  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 function renderSftAssumptionText() {
@@ -939,7 +922,7 @@ function renderSftAssumptionText() {
   if (!slot) return;
 
   slot.innerHTML = `
-    <p>The SFT is the maximum pension pot you can build in Ireland before extra tax charges apply. If your pension is above this limit at retirement, the excess is taxed at 40%.</p>
+    <p>The SFT is the maximum pension you can build in Ireland before extra tax charges apply. If your pension is above this limit at retirement, the excess is taxed at 40%.</p>
     <p><strong>Current path:</strong> The SFT increases by €200,000 each year, rising from €2.0m in 2025 to €2.8m in 2029. For years after 2029, the Government has said it will link the SFT to wage inflation, but no figures are confirmed. In this tool, we conservatively hold the limit at €2.8m until official guidance is released.</p>
   `;
 }
@@ -952,51 +935,6 @@ function formatEuro(n) {
   }
 }
 
-function updateSftMiniWarning(state) {
-  const pill = document.getElementById('sft-mini-warning');
-  const btn = document.getElementById('sftMiniLink');
-  if (!pill || !btn || !state) return;
-
-  const year = Number.isFinite(state.retirementAge)
-    ? (new Date().getFullYear() + Math.max(0, state.retirementAge - (state.currentAge || state.retirementAge)))
-    : new Date().getFullYear();
-
-  const limit = getEffectiveSftLimit(year, !!state.hasPartner);
-
-  const projectedOver = Number.isFinite(state.projectedPot) && state.projectedPot > limit;
-  const requiredOver  = Number.isFinite(state.requiredPot)  && state.requiredPot  > limit;
-
-  const nearBand = 0.9 * limit;
-  const projectedNear = !projectedOver && Number.isFinite(state.projectedPot) && state.projectedPot >= nearBand;
-  const requiredNear  = !requiredOver  && Number.isFinite(state.requiredPot)  && state.requiredPot  >= nearBand;
-
-  let text = '';
-  let tone = '';
-
-  if (projectedOver) {
-    const diff = state.projectedPot - limit;
-    text = `Your pension is projected to exceed the SFT by ${formatEuro(diff)}. What’s this?`;
-    tone = 'over';
-  } else if (requiredOver) {
-    const diff = state.requiredPot - limit;
-    text = `Your target (required) pot exceeds the SFT by ${formatEuro(diff)}. What’s this?`;
-    tone = 'over';
-  } else if (projectedNear || requiredNear) {
-    text = `Close to the SFT limit. Learn more`;
-    tone = 'near';
-  }
-
-  pill.classList.remove('is-over', 'is-near');
-  if (tone === 'over') pill.classList.add('is-over');
-  if (tone === 'near') pill.classList.add('is-near');
-
-  const label = document.querySelector('.sft-mini-warning__text');
-  if (label) label.textContent = text || '';
-
-  setHidden(pill, !text);
-
-  btn.onclick = scrollToAssumptionSft;
-}
 
 // ----- Contribution accessors (align keys if needed) -----
 const CONTRIB_KEYS = {
@@ -1045,17 +983,6 @@ function recomputeAndRefreshUI(){
 
   if (typeof renderResultsCharts==='function') renderResultsCharts(store);
   else if (typeof updateCharts==='function') updateCharts(store);
-
-  if (typeof updateSftMiniWarning === 'function') {
-    const currentAge = store.dobSelf ? Math.floor((Date.now() - new Date(store.dobSelf)) / (1000*60*60*24*365.25)) : undefined;
-    updateSftMiniWarning({
-      projectedPot: Number(store.projectedPotAtRetirement ?? store.projectedPot ?? 0),
-      requiredPot:  Number(store.financialFreedomTarget   ?? store.fyTarget    ?? 0),
-      retirementAge: Number(store.retireAge ?? store.retirementAge ?? store.desiredRetirementAge ?? 65),
-      currentAge,
-      hasPartner: !!(store.partnerDOB || store.partnerIncluded || store.hasPartner)
-    });
-  }
 }
 
 function withBusy(btn, fn){
@@ -1285,7 +1212,6 @@ export function renderResults(mountEl, storeRef = {}) {
     const age       = Number(storeRef.desiredRetirementAge     ?? storeRef.retirementAge ?? storeRef.retireAge ?? 65);
     const deficit   = Math.max(required - projected, 0);
     const partnerIncluded = !!(storeRef.partnerDOB || storeRef.partnerIncluded || storeRef.hasPartner);
-    const currentAge = storeRef.dobSelf ? Math.floor((Date.now() - new Date(storeRef.dobSelf)) / (1000*60*60*24*365.25)) : null;
 
     const atMaxContrib = (() => {
       const k = firstKey(storeRef, CONTRIB_KEYS.monthlyEuro);
@@ -1336,19 +1262,25 @@ export function renderResults(mountEl, storeRef = {}) {
     chips.appendChild(makeMetricChip('Required',     formatEUR(required)));
     hero.appendChild(chips);
 
-    const sftPill = document.createElement('div');
-    sftPill.id = 'sft-mini-warning';
-    sftPill.className = 'sft-mini-warning';
-    sftPill.setAttribute('role', 'note');
-    sftPill.setAttribute('aria-live', 'polite');
-    sftPill.hidden = true;
-    sftPill.innerHTML = `
-      <button class="sft-mini-warning__btn" id="sftMiniLink" type="button" aria-label="Learn about the SFT and potential charges">
-        <span class="sft-mini-warning__icon">⚠️</span>
-        <span class="sft-mini-warning__text">Potential SFT charge — What’s this?</span>
-      </button>
-    `;
-    hero.appendChild(sftPill);
+    const retirementYear = storeRef.retirementYear || (lastPensionOutput?.retirementYear) || null;
+    const yearAwareSFT   = (retirementYear != null) ? sftForYear(retirementYear) : null;
+
+    // Optional hero warning chip if FY target breaches SFT for that year
+    if (required && yearAwareSFT && required > yearAwareSFT) {
+      const over = required - yearAwareSFT;
+      const warn = document.createElement('div');
+      warn.className = 'hero-sft-chip';
+      warn.setAttribute('role','note');
+      warn.innerHTML = `
+        <span class="icon" aria-hidden="true">⚠️</span>
+        Your target (required) <b>pension</b> exceeds the SFT for ${retirementYear} by <b>${formatEUR(over)}</b>. <button class="link-btn" type="button" id="sftInfoBtn">What’s this?</button>
+      `;
+      hero.appendChild(warn);
+
+      warn.querySelector('#sftInfoBtn')?.addEventListener('click', () => {
+        document.getElementById('compliance-notices')?.scrollIntoView({ behavior:'smooth', block:'start' });
+      });
+    }
 
     const parts = [];
     if (nudgeCounts['contrib+200']>0 || nudgeCounts['contrib-200']>0){
@@ -1448,13 +1380,6 @@ export function renderResults(mountEl, storeRef = {}) {
     mountEl.appendChild(hero);
 
     renderSftAssumptionText();
-    updateSftMiniWarning({
-      projectedPot: projected,
-      requiredPot: required,
-      retirementAge: age,
-      currentAge,
-      hasPartner: partnerIncluded
-    });
 
     const revealHero = () => hero.classList.add('reveal--in');
     if (typeof requestAnimationFrame === 'function') {

--- a/index.html
+++ b/index.html
@@ -499,7 +499,7 @@
   <section id="full-monty" class="hero" aria-label="All-in-one planner">
     <div class="hero-copy">
       <h1>Are you on track to reach financial freedom?</h1>
-      <p class="lead">We project your pension under two scenarios: 1) Keep your current contributions exactly as they are, and 2) Increase to the maximum tax-relievable personal contributions. Then explore different risk profiles and retirement ages to see realistic ways to hit your freedom number (the pot needed to fund your lifestyle without a salary).</p>
+      <p class="lead">We project your pension under two scenarios: 1) Keep your current contributions exactly as they are, and 2) Increase to the maximum tax-relievable personal contributions. Then explore different risk profiles and retirement ages to see realistic ways to hit your freedom number (the pension needed to fund your lifestyle without a salary).</p>
     </div>
 
     <div class="hero-card" role="region" aria-label="Full Monty all-in-one">

--- a/styles/results.css
+++ b/styles/results.css
@@ -39,3 +39,23 @@
 .notice-card .title{ font-weight:800; margin-bottom:4px; }
 .notice-card .meta{ font-size:.9rem; opacity:.9; }
 .notice-card .actions{ display:none !important; } /* remove any mini-buttons if present */
+
+.hero-sft-chip{
+  background: #4e2b2b;
+  color: #ffdede;
+  border: 1px solid rgba(255,0,0,.35);
+  border-radius: 16px;
+  padding: .65rem .9rem;
+  margin: .6rem auto 0;
+  max-width: 32rem;
+  text-align: center;
+  font-weight: 700;
+}
+.hero-sft-chip .link-btn{
+  background: transparent;
+  border: 0;
+  color: #fff;
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+}


### PR DESCRIPTION
## Summary
- replace legacy SFT sections with dynamic cards that calculate the correct limit for the selected retirement year and use "pension" wording
- warn in the hero when the required pension exceeds that year's SFT and link to details; add matching styles
- update chart labels and copy to say "pension" instead of "pot" and tweak landing page wording

## Testing
- `node -e "import('./shared/assumptions.js').then(m=>{console.log('2026',m.sftForYear(2026));console.log('2027',m.sftForYear(2027));console.log('2028',m.sftForYear(2028));console.log('2029',m.sftForYear(2029));console.log('2030',m.sftForYear(2030));})"`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b43289291c8333ab607d062cbce077