### PR TITLE
Use payload for retirement year and max flag

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -106,6 +106,7 @@ function buildHeroPayload(){
     fyTarget: fyReq,
     desiredRetirementAge: lastWizard?.retireAge,
     retirementAge: lastWizard?.retireAge,
+    retirementYear: lastPensionOutput?.retirementYear ?? null,
     partnerIncluded: !!lastFYOutput?._inputs?.hasPartner,
     partnerDOB: lastFYOutput?._inputs?.partnerDob || null,
     useMaxContributions: !!useMax


### PR DESCRIPTION
## Summary
- read retirement year and max contributions flag from the render payload
- compute SFT warning using the payload's year only
- include retirement year in results payload

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b435de2408833397e1dc54c7574547