### PR TITLE
Restore original contribution controls

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -573,38 +573,6 @@
       <div class="results-shell">
         <section id="resultsView" aria-live="polite"></section>
 
-        <!-- [FM-CONTROLS] Scenario toggle + Increment chips -->
-        <div id="fm-contrib-controls" class="fm-contrib-controls" data-active="results-only" hidden>
-          <div class="fm-toggle-row" role="group" aria-label="Contribution scenario">
-            <button type="button" class="fm-toggle-btn is-active" data-scenario="current" id="fmScenarioCurrent">
-              Current Contributions
-            </button>
-            <button type="button" class="fm-toggle-btn" data-scenario="max" id="fmScenarioMax">
-              Max Tax-Relief
-            </button>
-          </div>
-
-          <div class="fm-chips-row" aria-label="Quick add monthly contribution">
-            <button type="button" class="fm-chip" data-increment="200">+ €200 /mo</button>
-            <button type="button" class="fm-chip" data-increment="400">+ €400 /mo</button>
-            <button type="button" class="fm-chip" data-increment="600">+ €600 /mo</button>
-            <button type="button" class="fm-chip" data-increment="1000">+ €1,000 /mo</button>
-            <button type="button" class="fm-chip is-revert" data-action="revert" id="fmRevert" aria-disabled="true">Revert</button>
-          </div>
-
-          <div class="fm-inline-notice" id="fmCapNotice" role="status" hidden>
-            <p class="fm-notice-text">
-              You’ve exceeded the maximum tax-relief limit for your age band.
-              <button type="button" class="fm-notice-cta" id="fmSwitchToMax">Switch to Max scenario</button>
-            </p>
-          </div>
-
-          <div class="fm-microcopy" id="fmChipHint" hidden>
-            Tip: tap chips to model higher monthly contributions. We’ll keep track so you can revert anytime.
-            <span class="fm-chip-count" id="fmChipCount" aria-live="polite"></span>
-          </div>
-        </div>
-
       <!-- ===== BEFORE RETIREMENT ===== -->
         <section class="results-phase" id="phase-pre">
         <header class="fm-section-head">

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -744,23 +744,7 @@
   margin: 0 0 8px 0;
 }
 
-/* [FM] Contribution controls */
-.fm-contrib-controls { margin-block: 1rem 1.25rem; display: grid; gap: .75rem; }
-.fm-toggle-row { display: inline-flex; border: 1px solid var(--accentA, #0f0); border-radius: 999px; padding: .25rem; }
-.fm-toggle-btn { appearance: none; border: 0; background: transparent; padding: .5rem .9rem; border-radius: 999px; font: inherit; cursor: pointer; }
-.fm-toggle-btn.is-active { background: rgba(0,0,0,.06); outline: 2px solid transparent; }
-.fm-chips-row { display: flex; flex-wrap: wrap; gap: .5rem; }
-.fm-chip { border: 1px dashed var(--accentA, #0f0); border-radius: 999px; padding: .45rem .8rem; background: transparent; cursor: pointer; font: inherit; }
-.fm-chip:hover, .fm-chip:focus { outline: 2px solid transparent; background: rgba(0,0,0,.04); }
-.fm-chip.is-revert[aria-disabled="true"] { opacity: .5; cursor: not-allowed; }
-.fm-inline-notice { border-left: 3px solid var(--accentB, #6c5ce7); padding: .5rem .75rem; background: rgba(108,92,231,.08); border-radius: .25rem; }
-.fm-notice-text { margin: 0; display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
-.fm-notice-cta { appearance: none; border: 0; border-bottom: 1px solid currentColor; background: transparent; cursor: pointer; padding: 0 .15rem; }
-.fm-microcopy { font-size: .875rem; opacity: .85; }
-@media (max-width: 480px) {
-  .fm-toggle-row { width: 100%; justify-content: space-between; }
-  .fm-chips-row { gap: .4rem; }
-}
+/* [FM] Contribution controls removed */
 
 /* Undo/restore row */
 .revert-row{


### PR DESCRIPTION
## Summary
- remove experimental segmented toggle and quick chip markup
- drop related styles for toggle and chip controls
- reinstate original Max Contributions switch & hero chip logic with session persistence and cap warnings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b446e2d70483338e123a137d1e42d1