### PR TITLE
Mount Max Contributions toggle beneath hero

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -572,6 +572,7 @@
     <main id="fm-results" class="fm-results-root">
       <div class="results-shell">
         <section id="resultsView" aria-live="polite"></section>
+        <div id="belowHeroControls" class="results-controls" aria-live="polite"></div>
 
       <!-- ===== BEFORE RETIREMENT ===== -->
         <section class="results-phase" id="phase-pre">
@@ -587,14 +588,6 @@
           <div class="fm-section-tools">
             <span class="range-badge">Now → Age <strong id="chipRetAgeA">65</strong></span>
             <span class="assumption-chip" id="chipAssumptionWrap"><strong>Assumption:</strong> <span id="chipAssumption">Current contributions</span></span>
-            <label class="toggle toggle--max" for="maxContribToggle" id="maxToggleWrap" title="Max Contributions">
-              <input type="checkbox" id="maxContribToggle" />
-              <div class="track">
-                <span class="knob" aria-hidden="true"></span>
-                <span class="label toggle-text">Max Contributions</span>
-              </div>
-            </label>
-            <span class="toggle-note">(assumes age-band tax-relief limits on €115k salary cap)</span>
           </div>
         </header>
 


### PR DESCRIPTION
## Summary
- Add a below-hero results-controls slot and remove old inline Max Contributions toggle.
- Introduce `setUseMaxContributions` controller and programmatic toggle mounting.
- Mount toggle after DOM ready, renderer ready, and major result events to keep UI in sync.

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b4622e62448333ae9c6f0b36ebcd65