### PR TITLE
feat: add action dock for contributions

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -572,9 +572,28 @@
     <main id="fm-results" class="fm-results-root">
       <div class="results-shell">
         <section id="resultsView" aria-live="polite"></section>
-        <section id="maxContribToggle">
-          <div id="belowHeroControls" class="results-controls" aria-live="polite"></div>
-        </section>
+
+        <!-- Action Dock template (cloned into hero) -->
+        <template id="tplContribActionDock">
+          <!-- Action Dock: shows context actions right where the user is interacting -->
+          <div id="contribActionDock" class="contrib-action-dock" aria-live="polite">
+            <!-- Revert appears only once user changes contributions -->
+            <button id="btnRevertContrib" class="btn-ghost-micro" type="button" hidden>
+              ⟲ Revert to original
+            </button>
+
+            <!-- Assist bar appears only if over tax-relief limit -->
+            <div id="assistMaxContrib" class="assist-bar" hidden>
+              <span class="assist-text">
+                ⚠️ You’re above the tax-relief limit.
+                <a id="lnkSeeLimit" href="#taxReliefLimits" class="assist-link">See your limit ↓</a>
+              </span>
+              <button id="btnGoToMax" class="btn-cta-mini" type="button">Max Contributions</button>
+            </div>
+          </div>
+        </template>
+
+        <section id="maxContribToggle" class="results-controls" aria-live="polite"></section>
 
       <!-- ===== BEFORE RETIREMENT ===== -->
         <section class="results-phase" id="phase-pre">

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -678,18 +678,6 @@
   box-shadow:none;
 }
 
-/* Helper block shown at max */
-.helper-note{
-  margin-top:8px;
-  background: var(--bg-elev-1);
-  border: 1px dashed rgba(255,255,255,.2);
-  border-radius:12px;
-  padding:12px;
-  color:var(--text-2);
-}
-.helper-note strong{ color:var(--text-1); }
-.helper-actions{ display:flex; justify-content:center; margin-top:8px; }
-
 /* Mini SFT warning pill under the two oval chips */
 .sft-mini-warning {
   margin-top: 10px;
@@ -742,13 +730,6 @@
 /* Assumption card typographic polish (optional) */
 #assumption-sft .assumption-body p {
   margin: 0 0 8px 0;
-}
-
-/* [FM] Contribution controls removed */
-
-/* Undo/restore row */
-.revert-row{
-  display:flex; gap:12px; justify-content:center; margin-top:4px;
 }
 
 /* --------- SCROLL AFFORDANCE (always visible) --------- */
@@ -889,28 +870,12 @@
   opacity: .95;
 }
 
-/* Undo/Restore row */
-.revert-row { display: flex; gap: 12px; justify-content: center; }
-.btn-text   { background: transparent; color: var(--text-2, rgba(255,255,255,.72)); text-decoration: underline; }
-
 /* Optional: change-summary under chips */
 .change-summary{
   text-align:center;
   color: var(--text-2, rgba(255,255,255,.72));
   margin-top: 4px;
 }
-
-.helper-note{
-  margin-top: 10px;
-  padding: 12px;
-  border-radius: 12px;
-  background: var(--bg-elev-1, rgba(255,255,255,.06));
-  border: 1px dashed rgba(255,255,255,.22);
-  color: var(--text-2, rgba(255,255,255,.72));
-}
-.helper-note strong{ color: var(--text-1, #fff); display:block; margin-bottom:4px; }
-.helper-sub{ margin-top: 2px; }
-.helper-actions{ display:flex; justify-content:center; margin-top:8px; }
 
 /* Mini SFT warning pill under the two oval chips */
 .sft-mini-warning {
@@ -1068,4 +1033,88 @@
     padding: 6px 10px;
     font-size: 12px;
   }
+}
+
+/* ===== Action Dock beneath contribution controls ===== */
+.contrib-action-dock {
+  display: grid;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+/* Revert: ghost micro-button (distinct from hero pills) */
+.btn-ghost-micro {
+  justify-self: end;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.04);
+  color: var(--text-on-dark, #EAF3EF);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, opacity 200ms ease;
+}
+.btn-ghost-micro:hover,
+.btn-ghost-micro:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+  outline: none;
+}
+
+/* Assist bar: compact inline card with CTA */
+.assist-bar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.18);
+  background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(0,0,0,0.08));
+  padding: 10px 12px;
+  will-change: opacity, transform;
+}
+
+/* Text + link */
+.assist-text {
+  font-size: 13px;
+  color: var(--text-on-dark, #EAF3EF);
+}
+.assist-link {
+  margin-left: 8px;
+  text-decoration: underline;
+  opacity: 0.9;
+}
+
+/* Small CTA distinct from pills */
+.btn-cta-mini {
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--accentA, #39FF14);
+  background: rgba(0,0,0,0.35);
+  color: var(--text-on-dark, #EAF3EF);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+.btn-cta-mini:hover,
+.btn-cta-mini:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+  outline: none;
+}
+
+/* Reveal animation */
+.reveal-in {
+  animation: assistReveal 220ms ease-out forwards;
+}
+@keyframes assistReveal {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Mobile tweaks */
+@media (max-width: 560px) {
+  .btn-ghost-micro, .btn-cta-mini { font-size: 12px; }
+  .assist-text { font-size: 12px; }
 }


### PR DESCRIPTION
## Summary
- add Action Dock template under hero for contribution controls
- style Action Dock with ghost and assist bar elements
- wire Action Dock logic and remove old below-hero controls

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ae6032408333b365e54ad7799ab7