### PR TITLE
Simplify pension contribution toggle messaging

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -335,7 +335,18 @@
     }
 
     .toggle-note{
-      color:#a6ffd8; font-weight:700;
+      margin-top: .35rem;
+      font-size: .92rem;
+      color: #cfeee1;
+    }
+    .btn-text-mini{
+      background: transparent;
+      border: 0;
+      font: inherit;
+      color: inherit;
+      text-decoration: underline;
+      cursor: pointer;
+      padding: 0;
     }
 
     .max-table-section{

--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -355,6 +355,13 @@ window.setRetirementIncomeColorsForToggle = setRetirementIncomeColorsForToggle;
 function onMaxContribsToggleChanged(isOn){
   setRetirementIncomeColorsForToggle(isOn);
   if (typeof updateAssumptionChip === 'function') updateAssumptionChip(isOn);
+
+  const note = document.getElementById('maxToggleNote');
+  if (note){
+    note.innerHTML = isOn
+      ? 'Using your age-band maximum eligible for tax relief. <button class="btn-text-mini" id="viewMaxLimits" type="button">View limits</button>'
+      : '';
+  }
 }
 window.onMaxContribsToggleChanged = onMaxContribsToggleChanged;
 
@@ -606,46 +613,39 @@ function renderMaxContributionToggle(storeRef){
 
   const track = document.createElement('span');
   track.className = 'track';
-
   const lab = document.createElement('span');
   lab.className = 'label';
-
   const txt = document.createElement('span');
   txt.className = 'toggle-text';
-  // New wording
-  txt.textContent = 'Maximise tax-relievable contributions';
+  // ✨ Simpler, friendlier label:
+  txt.textContent = 'Maximise pension contributions';
   lab.appendChild(txt);
-
   const knob = document.createElement('span');
   knob.className = 'knob';
-
   track.appendChild(lab);
   track.appendChild(knob);
   label.appendChild(track);
   wrap.appendChild(label);
 
-  // Always-visible description (no “cap” wording)
-  const desc = document.createElement('div');
-  desc.className = 'toggle-note';
-  desc.setAttribute('aria-hidden','true');
-  desc.textContent = 'Automatically set your personal contributions to the maximum amount eligible for income-tax relief, based on your age band (applies to earnings up to €115,000).';
-  wrap.appendChild(desc);
-
-  // Status line that updates when ON
+  // Slim “on” confirmation. Hidden when off.
   const note = document.createElement('div');
   note.id = 'maxToggleNote';
   note.className = 'toggle-note';
   note.setAttribute('aria-live','polite');
-  note.textContent = chk.checked
-    ? 'Maximised to your tax-relievable limits — see your age-band breakdown below.'
+  note.innerHTML = chk.checked
+    ? 'Using your age-band maximum eligible for tax relief. <button class="btn-text-mini" id="viewMaxLimits" type="button">View limits</button>'
     : '';
   wrap.appendChild(note);
 
   chk.addEventListener('change', (e) => {
     setUseMaxContributions(e.target.checked);
-    note.textContent = e.target.checked
-      ? 'Maximised to your tax-relievable limits — see your age-band breakdown below.'
-      : '';
+  });
+
+  // Optional “View limits” jump
+  wrap.addEventListener('click', (e)=>{
+    const btn = e.target.closest('#viewMaxLimits');
+    if (!btn) return;
+    document.getElementById('maxTableSection')?.scrollIntoView({ behavior:'smooth', block:'start' });
   });
 
   return wrap;

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -1078,23 +1078,29 @@ function renderMaxContribToggle() {
     return;
   }
 
-  // Fallback (should rarely be used). Uses modern wording, no "cap".
+  // Fallback (should rarely be used). Uses simple label.
   host.innerHTML = '';
   const wrap = document.createElement('div');
   wrap.className = 'maxcontrib-toggle';
   wrap.innerHTML = `
-    <label class="toggle-row" for="useMaxContribSwitch">
-      <input id="useMaxContribSwitch" type="checkbox" />
-      <span class="toggle-label">Maximise tax-relievable contributions</span>
-    </label>
-    <div class="toggle-sub">
-      Automatically set your personal contributions to the maximum amount eligible for income-tax relief
-      (based on your age band, on earnings up to €115,000).
-    </div>
-  `;
+      <label class="toggle-row" for="useMaxContribSwitch">
+        <input id="useMaxContribSwitch" type="checkbox" />
+        <span class="toggle-label">Maximise pension contributions</span>
+      </label>
+      <div class="toggle-note" id="maxToggleNote" aria-live="polite"></div>
+    `;
   host.appendChild(wrap);
   const sw = wrap.querySelector('#useMaxContribSwitch');
+  const note = wrap.querySelector('#maxToggleNote');
   sw.checked = !!getUseMaxContributions();
+  if (sw.checked) {
+    note.innerHTML = 'Using your age-band maximum eligible for tax relief. <button class="btn-text-mini" id="viewMaxLimits" type="button">View limits</button>';
+  }
+  wrap.addEventListener('click', (e)=>{
+    const btn = e.target.closest('#viewMaxLimits');
+    if (!btn) return;
+    document.getElementById('maxTableSection')?.scrollIntoView({ behavior:'smooth', block:'start' });
+  });
   sw.addEventListener('change', () => {
     if (typeof window.setUseMaxContributions === 'function') {
       window.setUseMaxContributions(sw.checked);
@@ -1102,6 +1108,9 @@ function renderMaxContribToggle() {
       // very old fallback:
       setUseMaxContributions(sw.checked);
     }
+    note.innerHTML = sw.checked
+      ? 'Using your age-band maximum eligible for tax relief. <button class="btn-text-mini" id="viewMaxLimits" type="button">View limits</button>'
+      : '';
   });
 }
 
@@ -1225,8 +1234,8 @@ function setUseMaxContributions(enabled){
 
   recomputeAndRefreshUI();
   announce(enabled
-    ? 'Maximise tax-relievable contributions is on.'
-    : 'Maximise tax-relievable contributions is off.');
+    ? 'Maximise pension contributions is on.'
+    : 'Maximise pension contributions is off.');
 }
 
 // Only publish the fallback if nothing else has registered yet.


### PR DESCRIPTION
## Summary
- Reword maximise toggle to “Maximise pension contributions” and show a lightweight confirmation line with a View limits link when active
- Lighten toggle note styling and add reusable mini-button styles
- Sync wizard fallback and announcements with the new maximise wording

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f88d71bc8333884a7b3cf05addb5