### PR TITLE
Fix max contribution toggle conflict and handle annual contributions

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -553,6 +553,35 @@
       height: var(--max-knob);
       pointer-events: none;
     }
+
+    /* Hero pills – a bit crisper */
+    .pill {
+      background:#2f2f2f;
+      border:1px solid rgba(255,255,255,.14);
+      border-radius:12px;
+      font-weight:800;
+    }
+    .pill.green { background:#0f2c22; border-color:rgba(0,255,136,.28); }
+    .pill.grey  { background:#2b2b2b; }
+
+    /* Micro “Revert” ghost */
+    .btn-ghost-micro{
+      background:transparent;
+      border:1px dashed rgba(255,255,255,.25);
+      color:#cfcfcf;
+      border-radius:999px;
+      padding:.35rem .7rem;
+      font-weight:700;
+    }
+
+    /* Inline nudge under the hero buttons */
+    .inline-warn{
+      display:inline-flex; gap:.4rem; align-items:center; margin-left:.5rem;
+      color:#ffd89b;
+    }
+    .inline-warn button{
+      background:transparent; border:0; color:#a6ffd8; text-decoration:underline; cursor:pointer;
+    }
   </style>
   <script src="ios-flag.js"></script>
   <script src="vh-fix.js"></script>


### PR DESCRIPTION
## Summary
- Remove wizard-mounted max contribution toggle so only results toggle renders
- Detect annual versus monthly contribution fields and convert values appropriately
- Add crisp pill and inline warning styles for contributions UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check fullMontyWizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc9648808333bceadee03c9e0ec2