### PR TITLE
Group pension inputs and style chips

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -630,43 +630,47 @@
 <section id="step-pensions" class="wizard-step" data-step="4">
   <h2 class="step-title">Pensions &amp; entitlements</h2>
 
-  <!-- Current pension value (UNCHANGED LABEL) -->
+  <!-- Current pension value (UNCHANGED) -->
   <label for="currentPensionValue" class="fm-label">Current pension value</label>
   <div class="input-with-chip">
     <input id="currentPensionValue" name="currentPensionValue" type="number" inputmode="decimal" placeholder="e.g. 20000" />
     <span class="unit-chip">€</span>
   </div>
 
-  <!-- YOUR contribution (MONTHLY) -->
-  <label for="userContribMonthly" class="fm-label">Your contribution (per month)</label>
-  <div class="input-with-chip">
-    <input id="userContribMonthly" name="userContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 250" />
-    <span class="unit-chip">€/mo</span>
+  <!-- ===== YOUR (EMPLOYEE) CONTRIBUTIONS ===== -->
+  <div class="contrib-group contrib-group--user" aria-label="Your contributions">
+    <label for="userContribMonthly" class="fm-label">Your contribution (per month)</label>
+    <div class="input-with-chip">
+      <input id="userContribMonthly" name="userContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 250" />
+      <span class="unit-chip">€/mo</span>
+    </div>
+    <p class="field-help">If you prefer, enter a % below.</p>
+
+    <div class="or-divider" aria-hidden="true"><span>OR</span></div>
+
+    <label for="userContribPct" class="fm-label">…or % of salary (you pay)</label>
+    <div class="input-with-chip">
+      <input id="userContribPct" name="userContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
+      <span class="unit-chip">%</span>
+    </div>
   </div>
-  <p class="field-help">If you prefer, enter a % below.</p>
 
-  <div class="or-divider" aria-hidden="true"><span>OR</span></div>
+  <!-- ===== EMPLOYER CONTRIBUTIONS (LARGER TOP GAP) ===== -->
+  <div class="contrib-group contrib-group--employer" aria-label="Employer contributions">
+    <label for="employerContribMonthly" class="fm-label">Employer contribution (per month)</label>
+    <div class="input-with-chip">
+      <input id="employerContribMonthly" name="employerContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 200" />
+      <span class="unit-chip">€/mo</span>
+    </div>
+    <p class="field-help">If you prefer, enter a % below.</p>
 
-  <label for="userContribPct" class="fm-label">…or % of salary (you pay)</label>
-  <div class="input-with-chip">
-    <input id="userContribPct" name="userContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
-    <span class="unit-chip">%</span>
-  </div>
+    <div class="or-divider" aria-hidden="true"><span>OR</span></div>
 
-  <!-- EMPLOYER contribution (MONTHLY) -->
-  <label for="employerContribMonthly" class="fm-label">Employer contribution (per month)</label>
-  <div class="input-with-chip">
-    <input id="employerContribMonthly" name="employerContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 200" />
-    <span class="unit-chip">€/mo</span>
-  </div>
-  <p class="field-help">If you prefer, enter a % below.</p>
-
-  <div class="or-divider" aria-hidden="true"><span>OR</span></div>
-
-  <label for="employerContribPct" class="fm-label">…or % of salary (employer)</label>
-  <div class="input-with-chip">
-    <input id="employerContribPct" name="employerContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
-    <span class="unit-chip">%</span>
+    <label for="employerContribPct" class="fm-label">…or % of salary (employer)</label>
+    <div class="input-with-chip">
+      <input id="employerContribPct" name="employerContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
+      <span class="unit-chip">%</span>
+    </div>
   </div>
 </section>
         </template>

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -280,11 +280,11 @@ function renderStepPensions(cont) {
   el.empEuro.closest('.input-with-chip')?.classList.remove('input-auto');
 
   // --- USER side ---
-  el.userEuro.addEventListener('input', () => {
+  el.userEuro.addEventListener('input', (e) => {
     el.userPct.value = '';
     el.userPct.disabled = true;
-    el.userEuro.readOnly = false;
-    el.userEuro.closest('.input-with-chip')?.classList.remove('input-auto');
+    e.target.readOnly = false;
+    e.target.closest('.input-with-chip')?.classList.remove('input-auto');
     savePensionState();
   });
 
@@ -299,12 +299,15 @@ function renderStepPensions(cont) {
       el.userEuro.value = euro.toFixed(2);
       el.userEuro.readOnly = true;
       el.userPct.disabled = false; // % stays editable
-      el.userEuro.closest('.input-with-chip')?.classList.add('input-auto');
     } else {
       el.userEuro.value = '';
       el.userEuro.readOnly = false;
-      el.userEuro.closest('.input-with-chip')?.classList.remove('input-auto');
     }
+
+    const wrap = el.userEuro.closest('.input-with-chip');
+    if (el.userEuro.readOnly) wrap?.classList.add('input-auto');
+    else wrap?.classList.remove('input-auto');
+
     savePensionState();
   });
 
@@ -313,11 +316,11 @@ function renderStepPensions(cont) {
   });
 
   // --- EMPLOYER side ---
-  el.empEuro.addEventListener('input', () => {
+  el.empEuro.addEventListener('input', (e) => {
     el.empPct.value = '';
     el.empPct.disabled = true;
-    el.empEuro.readOnly = false;
-    el.empEuro.closest('.input-with-chip')?.classList.remove('input-auto');
+    e.target.readOnly = false;
+    e.target.closest('.input-with-chip')?.classList.remove('input-auto');
     savePensionState();
   });
 
@@ -332,12 +335,15 @@ function renderStepPensions(cont) {
       el.empEuro.value = euro.toFixed(2);
       el.empEuro.readOnly = true;
       el.empPct.disabled = false;
-      el.empEuro.closest('.input-with-chip')?.classList.add('input-auto');
     } else {
       el.empEuro.value = '';
       el.empEuro.readOnly = false;
-      el.empEuro.closest('.input-with-chip')?.classList.remove('input-auto');
     }
+
+    const wrap = el.empEuro.closest('.input-with-chip');
+    if (el.empEuro.readOnly) wrap?.classList.add('input-auto');
+    else wrap?.classList.remove('input-auto');
+
     savePensionState();
   });
 

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -1331,18 +1331,17 @@
   opacity: 0.85;
 }
 
-/* Suffix chips inside inputs */
-.input-with-chip {
-  position: relative;
-}
+/* ===== Suffix chips inside inputs (align with your Step-2 neon look) ===== */
+.input-with-chip { position: relative; }
 
-.input-with-chip input {
+.input-with-chip input[type="number"],
+.input-with-chip input[type="text"] {
   width: 100%;
-  padding-right: 56px; /* room for chip */
-  text-align: right; /* numeric fields read better right-aligned */
+  padding-right: 56px;              /* room for chip on the right */
+  text-align: right;                 /* consistent with your income step */
 }
 
-/* Unit chip */
+/* The small pill at input's right (€, €/mo, %) */
 .unit-chip {
   position: absolute;
   right: 12px;
@@ -1359,19 +1358,20 @@
   border: 1px solid rgba(255,255,255,0.12);
 }
 
-/* Helper text: single line, subtle */
+/* Single helper line below € inputs */
 .field-help {
-  margin: 6px 0 10px 0;
+  margin: 6px 0 8px;
   font-size: 12px;
-  opacity: 0.7;
+  color: var(--text-2, #aaa);
+  opacity: 0.85;
 }
 
-/* OR divider between euro and percent blocks */
+/* OR divider between € and % (tight spacing within a pair) */
 .or-divider {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin: 10px 0 14px 0;
+  margin: 8px 0 12px;
   opacity: 0.8;
 }
 .or-divider::before,
@@ -1385,10 +1385,24 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--text-2, #aaa);
 }
 
-/* Disabled/auto state for mutual exclusivity */
-.input-auto input[readonly] {
-  opacity: 0.8;
+/* ===== Group spacing rules ===== */
+/* Within a group keep it compact */
+.contrib-group .fm-label { margin-top: 12px; }
+.contrib-group .or-divider + .fm-label { margin-top: 4px; }
+
+/* Larger gap between employee group and employer group */
+.contrib-group + .contrib-group { margin-top: 28px; }
+@media (min-width: 768px){
+  .contrib-group + .contrib-group { margin-top: 36px; }
+}
+
+/* Optional: subtle visual for auto-calculated € when % is entered */
+.input-with-chip.input-auto input[readonly]{
   background: rgba(255,255,255,0.04);
+  border-color: rgba(0,255,136,.25); /* matches your --glow tint */
+  box-shadow: none;
+  opacity: 0.95;
 }


### PR DESCRIPTION
## Summary
- Group employee and employer pension inputs under `.contrib-group` wrappers for easier spacing control
- Add neon-friendly chip, helper, divider, and group spacing styles for pension step
- Toggle `.input-auto` on auto-calculated euro fields when percent inputs are used

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b7062268d48333a9aba84db88172b6