### PR TITLE
Align pensions step input wrappers

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -626,50 +626,49 @@
         <div id="fmStepContainer" class="has-transform-on-desktop"></div>
 
         <template id="tpl-step-pensions">
-<!-- STEP 4: Pensions & entitlements -->
 <section id="step-pensions" class="wizard-step" data-step="4">
   <h2 class="step-title">Pensions &amp; entitlements</h2>
 
-  <!-- Current pension value (UNCHANGED) -->
+  <!-- Current pension value -->
   <label for="currentPensionValue" class="fm-label">Current pension value</label>
-  <div class="input-with-chip">
+  <div id="currentPensionValueWrap" class="input-wrap prefix">
+    <span>€</span>
     <input id="currentPensionValue" name="currentPensionValue" type="number" inputmode="decimal" placeholder="e.g. 20000" />
-    <span class="unit-chip">€</span>
   </div>
 
-  <!-- ===== YOUR (EMPLOYEE) CONTRIBUTIONS ===== -->
-  <div class="contrib-group contrib-group--user" aria-label="Your contributions">
+  <!-- ===== Employee (you) ===== -->
+  <div class="contrib-group contrib-group--user">
     <label for="userContribMonthly" class="fm-label">Your contribution (per month)</label>
-    <div class="input-with-chip">
+    <div id="userContribMonthlyWrap" class="input-wrap prefix">
+      <span>€</span>
       <input id="userContribMonthly" name="userContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 250" />
-      <span class="unit-chip">€/mo</span>
     </div>
     <p class="field-help">If you prefer, enter a % below.</p>
 
     <div class="or-divider" aria-hidden="true"><span>OR</span></div>
 
     <label for="userContribPct" class="fm-label">…or % of salary (you pay)</label>
-    <div class="input-with-chip">
+    <div id="userContribPctWrap" class="input-wrap suffix">
       <input id="userContribPct" name="userContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
-      <span class="unit-chip">%</span>
+      <span>%</span>
     </div>
   </div>
 
-  <!-- ===== EMPLOYER CONTRIBUTIONS (LARGER TOP GAP) ===== -->
-  <div class="contrib-group contrib-group--employer" aria-label="Employer contributions">
+  <!-- ===== Employer ===== -->
+  <div class="contrib-group contrib-group--employer">
     <label for="employerContribMonthly" class="fm-label">Employer contribution (per month)</label>
-    <div class="input-with-chip">
+    <div id="employerContribMonthlyWrap" class="input-wrap prefix">
+      <span>€</span>
       <input id="employerContribMonthly" name="employerContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 200" />
-      <span class="unit-chip">€/mo</span>
     </div>
     <p class="field-help">If you prefer, enter a % below.</p>
 
     <div class="or-divider" aria-hidden="true"><span>OR</span></div>
 
     <label for="employerContribPct" class="fm-label">…or % of salary (employer)</label>
-    <div class="input-with-chip">
+    <div id="employerContribPctWrap" class="input-wrap suffix">
       <input id="employerContribPct" name="employerContribPct" type="number" inputmode="decimal" placeholder="e.g. 5" />
-      <span class="unit-chip">%</span>
+      <span>%</span>
     </div>
   </div>
 </section>

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -1358,15 +1358,15 @@
   border: 1px solid rgba(255,255,255,0.12);
 }
 
-/* Single helper line below € inputs */
-.field-help {
-  margin: 6px 0 8px;
-  font-size: 12px;
-  color: var(--text-2, #aaa);
-  opacity: 0.85;
+/* Step 4 contribution spacing */
+.contrib-group .fm-label { margin-top: 12px; }
+.contrib-group .or-divider + .fm-label { margin-top: 4px; }
+
+.contrib-group + .contrib-group { margin-top: 28px; }
+@media (min-width: 768px){
+  .contrib-group + .contrib-group { margin-top: 36px; }
 }
 
-/* OR divider between € and % (tight spacing within a pair) */
 .or-divider {
   display: flex;
   align-items: center;
@@ -1379,7 +1379,7 @@
   content: "";
   height: 1px;
   flex: 1;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,.2), transparent);
 }
 .or-divider span {
   font-size: 11px;
@@ -1388,21 +1388,9 @@
   color: var(--text-2, #aaa);
 }
 
-/* ===== Group spacing rules ===== */
-/* Within a group keep it compact */
-.contrib-group .fm-label { margin-top: 12px; }
-.contrib-group .or-divider + .fm-label { margin-top: 4px; }
-
-/* Larger gap between employee group and employer group */
-.contrib-group + .contrib-group { margin-top: 28px; }
-@media (min-width: 768px){
-  .contrib-group + .contrib-group { margin-top: 36px; }
-}
-
-/* Optional: subtle visual for auto-calculated € when % is entered */
-.input-with-chip.input-auto input[readonly]{
-  background: rgba(255,255,255,0.04);
-  border-color: rgba(0,255,136,.25); /* matches your --glow tint */
-  box-shadow: none;
-  opacity: 0.95;
+.field-help {
+  margin: 6px 0 8px;
+  font-size: 12px;
+  color: var(--text-2, #aaa);
+  opacity: .85;
 }


### PR DESCRIPTION
## Summary
- Align pensions step fields with earlier steps using prefix and suffix input wrappers
- Add spacing utilities and dividers for employee/employer contribution groups

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70e9071688333ad8e110ce7c1084a