### PR TITLE
Align pension step currency prefixes

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -639,8 +639,8 @@
   <!-- ===== Employee (you) ===== -->
   <div class="contrib-group contrib-group--user">
     <label for="userContribMonthly" class="fm-label">Your contribution (per month)</label>
-    <div id="userContribMonthlyWrap" class="input-wrap prefix">
-      <span>€</span>
+    <div id="userContribMonthlyWrap" class="input-wrap prefix prefix--wide">
+      <span>€ / mo</span>
       <input id="userContribMonthly" name="userContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 250" />
     </div>
     <p class="field-help">If you prefer, enter a % below.</p>
@@ -657,8 +657,8 @@
   <!-- ===== Employer ===== -->
   <div class="contrib-group contrib-group--employer">
     <label for="employerContribMonthly" class="fm-label">Employer contribution (per month)</label>
-    <div id="employerContribMonthlyWrap" class="input-wrap prefix">
-      <span>€</span>
+    <div id="employerContribMonthlyWrap" class="input-wrap prefix prefix--wide">
+      <span>€ / mo</span>
       <input id="employerContribMonthly" name="employerContribMonthly" type="number" inputmode="decimal" placeholder="e.g. 200" />
     </div>
     <p class="field-help">If you prefer, enter a % below.</p>

--- a/styles/inputs.css
+++ b/styles/inputs.css
@@ -47,6 +47,60 @@
   color: var(--field-muted);
 }
 
+/* Keep wrapper inline-flex so children can be vertically centered */
+.input-wrap{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+}
+
+/* Step-2 canonical offsets you showed:
+   .input-wrap has padding: .55rem .7rem; 
+   .input-wrap.prefix adds padding-left: 1.8rem (seen in your DevTools).  */
+
+/* Ensure the prefix variant always gets the same extra left space as Step 2 */
+.input-wrap.prefix{ 
+  padding-left:1.8rem;
+}
+
+/* Place the prefix chip at the same visual offset and vertically centered */
+.input-wrap.prefix>span{
+  position:absolute;
+  left:.7rem;
+  top:50%;
+  transform:translateY(-50%);
+  line-height:1;
+  color:var(--field-ink);
+  opacity:1;
+  pointer-events:none;
+}
+
+/* Suffix (Step 3) — mirror the same approach for consistency */
+.input-wrap.suffix{ 
+  padding-right:1.8rem;
+}
+.input-wrap.suffix>span{
+  position:absolute;
+  right:.7rem;
+  top:50%;
+  transform:translateY(-50%);
+  line-height:1;
+  color:var(--field-ink);
+  opacity:1;
+  pointer-events:none;
+}
+
+/* WIDE prefix for “€ / mo” on monthly fields: 
+   Reserve extra space so text is centered and not hugging the edge. */
+.input-wrap.prefix.prefix--wide{ 
+  padding-left:3.9rem;
+}
+
+/* (Optional) tighten input’s own left padding if you added any elsewhere.
+   We rely on wrapper padding to create space; no extra input padding needed. */
+.input-wrap.prefix input{ padding-left:0; }
+.input-wrap.suffix input{ padding-right:0; }
+
 /* Optional sizes */
 .input-sm input{ min-width:5ch; }
 .input-lg input{ min-width:10ch; }


### PR DESCRIPTION
## Summary
- Align Step 4 pension euro prefixes with Step 2/3 layout
- Add wide "€ / mo" prefix variant and positioning rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7191ca954833388f64f135de93e59