### PR TITLE
Remove stray closing section in full-monty wizard

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -843,9 +843,10 @@
       </section>
       <div id="calcWarnings" style="display:none;"></div>
       </div>
-    </main>
+      </main>
+    </section>
     <button id="editInputsFab" class="fab" aria-label="Edit inputs" type="button" style="display:none">Edit inputs</button>
-  </section>
+    <!-- removed stray </section> -->
 
   <!-- Bottom Sheet: Tax Relief Explainer -->
   <div id="sheetTaxRelief" class="sheet" role="dialog" aria-modal="true" aria-labelledby="sheetTitle" hidden>


### PR DESCRIPTION
## Summary
- remove unmatched `</section>` after "Edit inputs" button
- ensure results section closes before floating action button

## Testing
- `tidy -qe full-monty.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b763b8b25c833396a1c2414ff16b2f