### PR TITLE
Fix wizard personal contribution caps and rendering

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -54,6 +54,16 @@ function toNumber(v) {
   return isNaN(n) ? 0 : n;
 }
 
+// Revenue age bands (personal contributions only)
+const IRL_AGE_BANDS = [
+  { min: 0,  max: 29, pct: 15 },
+  { min: 30, max: 39, pct: 20 },
+  { min: 40, max: 49, pct: 25 },
+  { min: 50, max: 54, pct: 30 },
+  { min: 55, max: 59, pct: 35 },
+  { min: 60, max: 200, pct: 40 }
+];
+
 // ───────────────────────────────────────────────────────────────
 // Data store and helpers
 // ----------------------------------------------------------------
@@ -260,134 +270,6 @@ renderStepGoal.validate = () => {
   return (typeof v === 'number' && v >= 0 && v <= 100) ? { ok:true } : { ok:false, message:'Enter a % between 0 and 100.' };
 };
 
-// ===== Max tax-relievable personal contribution logic (Ireland) =====
-// Revenue age bands (personal only), applied to earnings cap €115,000
-const IRL_EARNINGS_CAP = 115000;
-const IRL_AGE_BANDS = [
-  { min: 0,   max: 29, pct: 15 },
-  { min: 30,  max: 39, pct: 20 },
-  { min: 40,  max: 49, pct: 25 },
-  { min: 50,  max: 54, pct: 30 },
-  { min: 55,  max: 59, pct: 35 },
-  { min: 60,  max: 200, pct: 40 },
-];
-
-function toNum(v){ const n = parseFloat(String(v).replace(/[^\d.-]/g,'')); return isNaN(n)?0:n; }
-function formatEuro(x){ return Number(x).toLocaleString(undefined,{minimumFractionDigits:2, maximumFractionDigits:2}); }
-
-function resolveAnnualSalary(){
-  if (fullMontyStore?.grossIncome) return toNum(fullMontyStore.grossIncome);
-  const el = document.getElementById('grossIncome');
-  return toNum(el?.value || 0);
-}
-
-function resolveUserAge(){
-  if (typeof fullMontyStore?.age === 'number') return fullMontyStore.age;
-  if (fullMontyStore?.dobSelf){
-    const dob = new Date(fullMontyStore.dobSelf);
-    if (!isNaN(dob)){
-      const today = new Date();
-      let a = today.getFullYear() - dob.getFullYear();
-      const m = today.getMonth() - dob.getMonth();
-      if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) a--;
-      return a;
-    }
-  }
-  return 40;
-}
-
-function maxReliefPercentByAge(age){
-  const band = IRL_AGE_BANDS.find(b => age>=b.min && age<=b.max) || IRL_AGE_BANDS[IRL_AGE_BANDS.length-1];
-  return band.pct;
-}
-function monthlyPersonalMaxEuro(){
-  const annual = resolveAnnualSalary();
-  const age = resolveUserAge();
-  const capBase = Math.min(annual, IRL_EARNINGS_CAP);
-  return (capBase * maxReliefPercentByAge(age)) / 100 / 12;
-}
-
-// Show / hide cap note helpers
-function showEuroCapNote(msg){
-  const n = document.getElementById('userEuroCapNote'); if(!n) return;
-  n.textContent = msg; n.style.display = 'block';
-}
-function hideEuroCapNote(){ const n = document.getElementById('userEuroCapNote'); if(n) n.style.display='none'; }
-
-function showPctCapNote(msg){
-  const n = document.getElementById('userPctCapNote'); if(!n) return;
-  n.textContent = msg; n.style.display = 'block';
-}
-function hidePctCapNote(){ const n = document.getElementById('userPctCapNote'); if(n) n.style.display='none'; }
-
-// ===== Hook into existing Step-4 handlers (PERSONAL ONLY) =====
-function enforcePersonalCaps(){
-  const euro = document.getElementById('userContribMonthly');
-  const pct  = document.getElementById('userContribPct');
-
-  if (!euro || !pct) return;
-
-  // When user types €/mo
-  euro.addEventListener('input', () => {
-    hideEuroCapNote(); hidePctCapNote();
-    const val = toNum(euro.value);
-    const cap = monthlyPersonalMaxEuro();
-    if (val > cap && cap > 0){
-      euro.value = formatEuro(cap);
-      showEuroCapNote(`Capped at €${formatEuro(cap)} per month — that’s the maximum eligible for income-tax relief at your age.`);
-    }
-  }, { capture: true });
-
-  // When user types % of salary
-  pct.addEventListener('input', () => {
-    hideEuroCapNote(); hidePctCapNote();
-    const ageMaxPct = maxReliefPercentByAge(resolveUserAge());
-    let p = toNum(pct.value);
-
-    if (p > ageMaxPct){
-      p = ageMaxPct;
-      pct.value = String(p);
-      showPctCapNote(`Capped at ${p}% — that’s the maximum eligible for income-tax relief at your age.`);
-    }
-
-    const monthlyCap = monthlyPersonalMaxEuro();
-    const monthlySalary = resolveAnnualSalary() / 12;
-    if (monthlySalary > 0){
-      let euroFromPct = (monthlySalary * p) / 100;
-      if (euroFromPct > monthlyCap){
-        euroFromPct = monthlyCap;
-        const effectivePct = (monthlyCap / monthlySalary) * 100;
-        pct.value = effectivePct.toFixed(2).replace(/\.00$/,'');
-        showPctCapNote(`Capped by the earnings limit — effective rate set to ${pct.value}%.`);
-      }
-      const euroField = document.getElementById('userContribMonthly');
-      if (euroField){
-        euroField.value = formatEuro(euroFromPct);
-        euroField.readOnly = true;
-      }
-    }
-  }, { capture: true });
-
-  ['blur','change'].forEach(ev => {
-    euro.addEventListener(ev, () => { if (toNum(euro.value) <= monthlyPersonalMaxEuro()) hideEuroCapNote(); });
-    pct.addEventListener(ev,  () => { if (toNum(pct.value) <= maxReliefPercentByAge(resolveUserAge())) hidePctCapNote(); });
-  });
-
-  // Optional: if salary or age changes elsewhere, re-cap current values
-  window.recheckPersonalCap = function(){
-    const cap = monthlyPersonalMaxEuro();
-    if (euro && toNum(euro.value) > cap){
-      euro.value = formatEuro(cap);
-      showEuroCapNote(`Capped at €${formatEuro(cap)} per month — max eligible for income-tax relief at your age.`);
-    }
-    const ageMaxPct = maxReliefPercentByAge(resolveUserAge());
-    if (pct && toNum(pct.value) > ageMaxPct){
-      pct.value = String(ageMaxPct);
-      showPctCapNote(`Capped at ${ageMaxPct}% — max eligible for income-tax relief at your age.`);
-    }
-  };
-}
-
 function renderStepPensions(cont) {
   const tmpl = document.getElementById('tpl-step-pensions');
   if (!tmpl) return;
@@ -421,27 +303,21 @@ function renderStepPensions(cont) {
 
     // --- USER side ---
     if (el.userEuro && el.userPct){
-      // Typing € -> disable % (until € cleared)
       el.userEuro.addEventListener('input', () => {
         if (el.userEuro.value && toNum(el.userEuro.value) > 0){
-          el.userPct.disabled = true;
+          el.userPct.value = '';
           el.userEuro.readOnly = false;
-        } else {
-          el.userPct.disabled = false;       // re-enable when empty
         }
         savePensionState();
       });
 
-      // Typing % -> compute €/mo, make € readOnly (not disabled)
       el.userPct.addEventListener('input', () => {
         const pct = toNum(el.userPct.value);
         if (pct > 0 && monthlySalary > 0){
           const euro = (monthlySalary * pct) / 100;
           el.userEuro.value = euro.toFixed(2);
           el.userEuro.readOnly = true;       // visually alive, just not editable
-          el.userPct.disabled = false;       // keep % editable
-        } else if (!el.userPct.value){
-          // Clearing % -> allow editing €
+        } else {
           el.userEuro.readOnly = false;
         }
         savePensionState();
@@ -452,10 +328,8 @@ function renderStepPensions(cont) {
     if (el.empEuro && el.empPct){
       el.empEuro.addEventListener('input', () => {
         if (el.empEuro.value && toNum(el.empEuro.value) > 0){
-          el.empPct.disabled = true;
+          el.empPct.value = '';
           el.empEuro.readOnly = false;
-        } else {
-          el.empPct.disabled = false;
         }
         savePensionState();
       });
@@ -466,8 +340,7 @@ function renderStepPensions(cont) {
           const euro = (monthlySalary * pct) / 100;
           el.empEuro.value = euro.toFixed(2);
           el.empEuro.readOnly = true;
-          el.empPct.disabled = false;
-        } else if (!el.empPct.value){
+        } else {
           el.empEuro.readOnly = false;
         }
         savePensionState();
@@ -521,7 +394,81 @@ function renderStepPensions(cont) {
     document.getElementById('currentPensionValue')?.addEventListener('input', savePensionState);
   })();
 
-  enforcePersonalCaps();
+  // Cap logic for employee contributions only
+  (function wirePersonalCapLogic(){
+    const euro = document.getElementById('userContribMonthly');
+    const pct  = document.getElementById('userContribPct');
+    const noteEuro = document.getElementById('userEuroCapNote');
+    const notePct  = document.getElementById('userPctCapNote');
+
+    if (!euro || !pct) return;
+
+    function showNote(el,msg){ if(el){ el.textContent=msg; el.style.display='block'; } }
+    function hideNote(el){ if(el){ el.style.display='none'; el.textContent=''; } }
+
+    function currentMonthlyCap(){
+      const dob = fullMontyStore.dobSelf || fullMontyStore.dob;
+      if(!dob) return Infinity;
+      const age = Math.floor((Date.now()-new Date(dob).getTime())/(365.25*24*3600*1000));
+      const salary = Number(fullMontyStore.grossIncome||0);
+      const cappedSalary = Math.min(salary, MAX_SALARY_CAP);
+      const band = IRL_AGE_BANDS.find(b => age>=b.min && age<=b.max) || IRL_AGE_BANDS[IRL_AGE_BANDS.length-1];
+      return (cappedSalary*band.pct)/100/12;
+    }
+    function maxPct(){
+      const dob = fullMontyStore.dobSelf || fullMontyStore.dob;
+      if(!dob) return 0;
+      const age = Math.floor((Date.now()-new Date(dob).getTime())/(365.25*24*3600*1000));
+      const band = IRL_AGE_BANDS.find(b => age>=b.min && age<=b.max);
+      return band?band.pct:0;
+    }
+
+    euro.addEventListener('input',()=>{
+      hideNote(noteEuro); hideNote(notePct);
+      const val = toNumber(euro.value);
+      const cap = currentMonthlyCap();
+      if(val>cap && isFinite(cap)){
+        euro.value = (cap).toFixed(2);
+        showNote(noteEuro, `Capped at €${cap.toFixed(2)} per month — maximum eligible for tax relief at your age.`);
+      }
+    });
+
+    pct.addEventListener('input',()=>{
+      hideNote(noteEuro); hideNote(notePct);
+      let p = toNumber(pct.value);
+      const maxp = maxPct();
+      if(p>maxp){ p = maxp; pct.value=String(p); showNote(notePct,`Capped at ${p}% — maximum eligible for tax relief at your age.`); }
+      const salary = Number(fullMontyStore.grossIncome||0);
+      if(salary>0){
+        let euroVal=(salary*p/100)/12;
+        const cap=currentMonthlyCap();
+        if(euroVal>cap){
+          euroVal=cap;
+          const effPct=(cap/(salary/12))*100;
+          pct.value=effPct.toFixed(2).replace(/\.00$/,'');
+          showNote(notePct,`Capped by earnings limit — effective rate set to ${pct.value}%.`);
+        }
+        euro.value=euroVal.toFixed(2);
+        euro.readOnly=true;
+      } else {
+        euro.readOnly=false;
+      }
+    });
+
+    function enforceCapOnLoad(){
+      const cap=currentMonthlyCap();
+      if(toNumber(euro.value)>cap && isFinite(cap)){
+        euro.value=cap.toFixed(2);
+        showNote(noteEuro,`Capped at €${cap.toFixed(2)} per month — maximum eligible for tax relief at your age.`);
+      }
+      const p=toNumber(pct.value); const maxp=maxPct();
+      if(p>maxp){
+        pct.value=String(maxp);
+        showNote(notePct,`Capped at ${maxp}% — maximum eligible for tax relief at your age.`);
+      }
+    }
+    enforceCapOnLoad();
+  })();
 }
 renderStepPensions.validate = () => ({ ok: true, errors: {} });
 


### PR DESCRIPTION
## Summary
- remove duplicate global cap logic that broke modal rendering
- wire contribution caps for employees inside `renderStepPensions` after DOM mount
- keep percent fields editable and clamp employee inputs against age-band limits with user-facing notes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d573df688333988825cd14bb48fc