### PR TITLE
Ensure restore button hides by default and show edit FAB on results

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -606,6 +606,71 @@
     /* Small count badge for repeated taps */
     .tap-badge{ margin-left:.35rem; background:#444; border-radius:999px; padding:.15rem .45rem; font-weight:800; font-size:.85rem; }
     .tap-badge.hidden{ display:none; }
+
+    /* === Universal hide utility (must be at end to win the cascade) === */
+    .hidden { display: none !important; }
+
+    /* Keep the restore button hidden when aria-hidden/hidden is set */
+    #resultsView #btnRestoreOriginal.hidden,
+    #resultsView [data-role="restore-original"].hidden,
+    #resultsView #btnRestoreOriginal[aria-hidden="true"],
+    #resultsView [data-role="restore-original"][aria-hidden="true"],
+    #resultsView #btnRestoreOriginal[hidden],
+    #resultsView [data-role="restore-original"][hidden]{
+      display: none !important;
+      visibility: hidden !important;
+      pointer-events: none !important;
+    }
+
+    /* === Edit inputs FAB visibility control by UI mode === */
+    /* Hidden by default (HTML currently has style="display:none" as well) */
+    #editInputsFab { display: none; }
+
+    /* Show only on results mode (uiMode.js sets data-ui-mode on <body>) */
+    body[data-ui-mode="results"] #editInputsFab {
+      display: inline-flex !important;
+      align-items: center;
+      gap: .5rem;
+    }
+
+    /* Apply the existing .fab-edit look to #editInputsFab too */
+    #editInputsFab,
+    .fab-edit{
+      background: var(--glow, #00ff88);
+      color: #0b1f16;
+      border: 1px solid rgba(0,255,136,.25);
+      border-radius: 999px;
+      font-weight: 800;
+      padding: .7rem 1rem;
+      box-shadow: 0 8px 24px rgba(0,255,136,.18), 0 0 0 2px rgba(0,255,136,.08) inset;
+      transition: transform .15s ease, box-shadow .2s ease, filter .2s ease;
+    }
+
+    /* Desktop: float bottom-right; mobile stays inline if needed */
+    @media (min-width: 980px){
+      #editInputsFab,
+      .fab-edit{
+        position: fixed;
+        right: 28px;
+        bottom: 28px;
+        z-index: 50;
+        padding: .9rem 1.25rem;
+        font-size: 1rem;
+      }
+    }
+
+    #editInputsFab:hover,
+    .fab-edit:hover{
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px rgba(0,255,136,.22), 0 0 0 2px rgba(0,255,136,.18) inset;
+      filter: saturate(1.05);
+    }
+
+    #editInputsFab:active,
+    .fab-edit:active{
+      transform: translateY(0);
+      box-shadow: 0 6px 16px rgba(0,255,136,.18), 0 0 0 2px rgba(0,255,136,.18) inset;
+    }
   </style>
   <script src="ios-flag.js"></script>
   <script src="vh-fix.js"></script>

--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -32,12 +32,24 @@ function getRestoreButton() {
 function setRestoreVisible(show) {
   const btn = getRestoreButton();
   if (!btn) return;
-  if (btn.classList) {
-    btn.classList.toggle('hidden', !show);
-  } else {
-    btn.style.display = show ? '' : 'none';
-  }
+
+  // classes + aria
+  btn.classList.toggle('hidden', !show);
+  btn.classList.toggle('is-hidden', !show);
   btn.setAttribute('aria-hidden', show ? 'false' : 'true');
+
+  // inline guarantees (beats any unexpected CSS)
+  if (!show) {
+    btn.style.display = 'none';
+    btn.style.visibility = 'hidden';
+    btn.style.pointerEvents = 'none';
+    btn.toggleAttribute('hidden', true);
+  } else {
+    btn.style.display = '';        // let CSS lay it out
+    btn.style.visibility = '';
+    btn.style.pointerEvents = '';
+    btn.toggleAttribute('hidden', false);
+  }
 }
 
 function updateRestoreVisibility() {
@@ -1371,3 +1383,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+// Keep restore hidden on any re-render of results
+(function observeRestoreInsertion(){
+  const root = document.getElementById('resultsView');
+  if (!root || window.__restoreObserver) return;
+
+  window.__restoreObserver = new MutationObserver(() => {
+    // Re-apply current visibility policy whenever results DOM changes
+    updateRestoreVisibility();
+  });
+
+  window.__restoreObserver.observe(root, { childList: true, subtree: true });
+})();


### PR DESCRIPTION
## Summary
- Hide "Return to original" button until user tweaks and keep it hidden when using max contributions
- Restore floating "Edit inputs" FAB on results view only

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check fullMontyResults.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8993ba01883339472fb267915e1f6