### PR TITLE
Centralize ARF/PRSA mandatory withdrawal warning

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -245,8 +245,8 @@ window.addEventListener('fm-renderer-ready', () => {
 });
 
 function renderComplianceNotices(container){
-  container = ensureNoticesMount() || container || document.getElementById('compliance-notices');
-  if (!container) return;
+  const el = ensureNoticesMount() || container || document.getElementById('compliance-notices');
+  if (!el) return;
 
   const projAtRet = projectedAtRetirementValue();
   const retireAge = lastWizard?.retireAge ?? null;
@@ -256,7 +256,7 @@ function renderComplianceNotices(container){
     ? lastPensionOutput.sftLimit
     : (retirementYr != null ? sftForYear(retirementYr) : null);
 
-  const warningsHTML = buildWarningsHTML(
+  const fmWarnings = buildWarningsHTML(
     {
       retireAge,
       retirementYear: retirementYr,
@@ -266,14 +266,8 @@ function renderComplianceNotices(container){
     { variant: 'fullmonty' }
   );
 
-  const mandatoryCard = `
-    <div class="warning-block">
-      ⚠️ <strong>Mandatory withdrawals (ARF / vested PRSA)</strong><br><br>
-      Minimum annual drawdowns apply in retirement under Revenue’s imputed-distribution rules. Our charts do <b>not</b> model these minimum withdrawals.
-    </div>
-  `;
-
-  container.innerHTML = `<div class="notice-cards">${warningsHTML}${mandatoryCard}</div>`;
+  el.innerHTML = '';
+  el.insertAdjacentHTML('beforeend', fmWarnings);
   document.querySelectorAll('.warning-block strong').forEach(s=>{
     if (s.textContent.trim() === 'Standard Fund Threshold (SFT) Assumptions') {
       s.closest('.warning-block')?.remove();
@@ -1096,7 +1090,7 @@ document.addEventListener('fm-pension-output', (e) => {
   const projValue = projectedAtRetirementValue();
   const sftLimit = lastPensionOutput?.sftLimit ?? (retirementYear ? sftForYear(retirementYear) : null);
 
-  const unifiedWarnings = buildWarningsHTML(
+  const warningsHTML = buildWarningsHTML(
     {
       retireAge,
       retirementYear,
@@ -1105,15 +1099,6 @@ document.addEventListener('fm-pension-output', (e) => {
     },
     { variant: 'fullmonty' }
   );
-
-  const mandatoryWarning = `
-  <div class="warning-block">
-    ⚠️ <strong>Mandatory Withdrawals (ARF / vested PRSA)</strong><br><br>
-    Revenue’s imputed distribution rules require minimum annual drawdowns from ARFs and vested PRSAs. Rates increase with age and may vary with overall ARF/vested PRSA size. Our charts do not model these minimum withdrawals; actual net income and fund paths may differ.
-  </div>
-`;
-
-  const warningsHTML = unifiedWarnings + mandatoryWarning;
   const cw = document.getElementById('calcWarnings');
   if (cw) {
     cw.innerHTML = warningsHTML;

--- a/pensionProjectionPage.js
+++ b/pensionProjectionPage.js
@@ -447,16 +447,12 @@ const retirementYear = new Date().getFullYear() + Math.ceil(yearsToRet);
 const sftLimit       = sftForYear(retirementYear);
 sftLimitGlobal = sftLimit;
 
-const unifiedWarnings = buildWarningsHTML({
+const warningsHTML = buildWarningsHTML({
   retireAge,
   retirementYear,
   projectedValue: projValue,
-  sftLimit,
-  personalAnnual: personalUsed,
-  employerAnnual: employerCalc
-});
-
-const warningsHTML = unifiedWarnings;
+  sftLimit
+}, { variant: 'block' });
 const resultsHTML = `
   <p>
     Max personal contribution allowed (age ${Math.floor(curAge)}):

--- a/shared/minWithdrawalsWarning.js
+++ b/shared/minWithdrawalsWarning.js
@@ -1,0 +1,24 @@
+export const MIN_WD_TITLE = 'Mandatory withdrawals (ARF / vested PRSA)';
+
+export function getMinWithdrawalsHTML({ variant = 'block' } = {}) {
+  const body = `
+    Irish Revenue rules require minimum annual withdrawals from Approved Retirement Funds (ARFs) and vested PRSAs once you reach retirement.<br><br>
+    Our charts do <strong>not</strong> model these withdrawals directly. However, a prudent investor who does not need to spend the full amount would typically reinvest the excess into assets of similar risk. While the tax treatment of reinvested funds may differ, this approach means the projections shown here still provide a realistic picture of long-term retirement outcomes.
+  `;
+
+  if (variant === 'fullmonty') {
+    return `
+      <div class="notice-card warn" data-warning="min-withdrawals">
+        <div class="title">${MIN_WD_TITLE}</div>
+        <div class="meta">${body}</div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="warning-block" data-warning="min-withdrawals">
+      ⚠️ <strong>${MIN_WD_TITLE}</strong><br><br>
+      ${body}
+    </div>
+  `;
+}

--- a/shared/warnings.js
+++ b/shared/warnings.js
@@ -3,6 +3,7 @@
 // Keep .warning-block structure so existing CSS/PDF code continues to work.
 
 import { getSftWarningHTML } from './sftWarning.js';
+import { getMinWithdrawalsHTML } from './minWithdrawalsWarning.js';
 
 /** Context contract all tools can provide */
 /// ctx = {
@@ -70,6 +71,7 @@ const REGISTRY = [agePre50, age50to59, ageOver70, age75Plus];
 export function buildWarningsHTML(ctx, { variant = 'block' } = {}) {
   const blocks = [];
   blocks.push(getSftWarningHTML({ ...ctx, variant }));
+  blocks.push(getMinWithdrawalsHTML({ variant }));
   REGISTRY.forEach(fn => blocks.push(fn(ctx)));
   return blocks.filter(Boolean).join('');
 }


### PR DESCRIPTION
## Summary
- Add shared `minWithdrawalsWarning` utility with reusable copy for ARF/vested PRSA mandatory withdrawals
- Register the new warning in `shared/warnings` and use registry from pension projection and Full Monty flows
- Render warnings via registry on Pension Projection page (`block` variant) and Full Monty results (`fullmonty` variant)

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72dcc6498833398f6fa2cc6bbec28