### PR TITLE
Wire edit inputs FAB to wizard mode toggle

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -1,7 +1,6 @@
 // fullMontyResults.js
 import { fyRequiredPot } from './shared/fyRequiredPot.js';
 import { sftForYear, CPI, STATE_PENSION, SP_START, MAX_SALARY_CAP } from './shared/assumptions.js';
-import { setUIMode } from './uiMode.js';
 import { buildWarningsHTML } from './shared/warnings.js';
 
 const AGE_BANDS = [
@@ -233,6 +232,9 @@ function renderHeroNowOrQueue(){
   const mount = document.getElementById('resultsView');
   if (typeof window.renderResults === 'function'){
     window.renderResults(mount, payload);
+    if (typeof window.setUIMode === 'function') {
+      window.setUIMode('results');
+    }
   } else {
     window.__pendingHeroPayload = payload;
   }
@@ -538,8 +540,6 @@ function mountBelowHeroToggle(){
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  setUIMode('results');
-
   // Ensure the Max toggle gets mounted into #belowHeroControls
   mountBelowHeroToggle();
 


### PR DESCRIPTION
## Summary
- add a shared UI mode controller in the wizard to manage the FAB, body attribute, and modal state
- delegate the edit inputs FAB click to reopen the wizard in input mode
- switch the UI into results mode after rendering the results payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c871bd349c83339df9431a38e386ea