### PR TITLE
Unify hero restore button handling

### DIFF
--- a/full-monty.html
+++ b/full-monty.html
@@ -762,15 +762,6 @@
           <div id="belowHeroControls" class="results-controls" aria-live="polite">
             <!-- Max Contributions toggle is injected here by fullMontyWizard.js -->
           </div>
-          <!-- Single restore button (fixed ID) -->
-          <button id="btnRestoreOriginal"
-                  class="pill pill--ghost"
-                  type="button"
-                  hidden
-                  aria-hidden="true"
-                  style="margin-left: 0;">
-            Return to original
-          </button>
         </section>
 
       <!-- ===== BEFORE RETIREMENT ===== -->


### PR DESCRIPTION
## Summary
- remove the duplicate static "Return to original" button from the below-hero controls so only the renderer's hero button remains
- update restore button helpers to prefer the hero instance, manage focusability, and handle clicks via delegation
- hide the restore control on renderer readiness to keep baseline views clean after re-renders

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68c8771db11c8333b2f77e1a800f1a21