### PR TITLE
Expose Full Monty store for results max contribution table

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -1331,16 +1331,25 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+function _currentFMStore(){
+  // preferred: live wizard store
+  const s = (window.getFullMontyData && window.getFullMontyData())
+         || (window.getStore && window.getStore());
+  if (s && Object.keys(s).length) return s;
+  // fallback: last FY inputs (has dob/grossIncome/partner flags)
+  return (lastFYOutput && lastFYOutput._inputs) ? lastFYOutput._inputs : {};
+}
+
 window.addEventListener('fm:results:ready', () => {
-  try { window.renderMaxContributionTable?.(window.getStore?.() || window.getFullMontyData?.() || {}); } catch(e){}
+  try { window.renderMaxContributionTable?.(_currentFMStore()); } catch(e){}
 });
 
 document.addEventListener('fm-salary-updated', () => {
-  try { window.renderMaxContributionTable?.(window.getStore?.() || window.getFullMontyData?.() || {}); } catch(e){}
+  try { window.renderMaxContributionTable?.(_currentFMStore()); } catch(e){}
 });
 
 document.addEventListener('DOMContentLoaded', () => {
-  try { window.renderMaxContributionTable?.(window.getStore?.() || window.getFullMontyData?.() || {}); } catch(e){}
+  try { window.renderMaxContributionTable?.(_currentFMStore()); } catch(e){}
 });
 
 // Keep restore hidden on any re-render of results

--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -1954,4 +1954,7 @@ window.navigateToInputs = openFullMontyWizard;
 window.getUseMaxContributions = getUseMaxContributions;
 window.getCurrentPersonalContribution = getCurrentPersonalContribution;
 window.setCurrentPersonalContributionAnnual = setCurrentPersonalContributionAnnual;
+// 🔧 Make the data getters visible to Results.js
+window.getFullMontyData = () => getStore();
+window.getStore = getStore;
 


### PR DESCRIPTION
## Summary
- expose the wizard store getters on `window` so the results view can access live data
- add a helper in the results script to prefer the live store and fall back to the FY inputs before rendering the max contribution table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9dde35b188333b677bf6a8e461010