### PR TITLE
Highlight max contribution cells

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -246,25 +246,24 @@ const maxPctForAge = age => AGE_BANDS.find(b => age <= b.max)?.pct ?? 0.15;
       // Self €
       const selfMax = perBandMaxEuro(selfSalary, b.pct);
       const tdSelf  = document.createElement('td');
+      tdSelf.className = 'max-euro self-euro';
       tdSelf.textContent = fmtEUR(selfMax);
+      // highlight the exact cell for user's band
       if (selfBand && selfBand.label === b.label) {
-        const badge = document.createElement('span');
-        badge.className = 'badge hl-self';
-        badge.textContent = 'You';
-        tdSelf.appendChild(badge);
+        tdSelf.classList.add('is-highlight-self');
+        tdSelf.setAttribute('data-hl', 'self');
       }
 
       // Partner €
       const tdPartner = document.createElement('td');
-      tdPartner.className = 'partner-col';
+      tdPartner.className = 'partner-col max-euro partner-euro';
       if (hasPartner) {
         const partnerMax = perBandMaxEuro(partnerSalary, b.pct);
         tdPartner.textContent = fmtEUR(partnerMax);
+        // highlight the exact cell for partner's band
         if (partnerBand && partnerBand.label === b.label) {
-          const badge = document.createElement('span');
-          badge.className = 'badge hl-partner';
-          badge.textContent = 'Partner';
-          tdPartner.appendChild(badge);
+          tdPartner.classList.add('is-highlight-partner');
+          tdPartner.setAttribute('data-hl', 'partner');
         }
       } else {
         tdPartner.setAttribute('hidden', 'true');

--- a/styles/results.css
+++ b/styles/results.css
@@ -100,3 +100,62 @@
 
 /* Let us hide the partner column entirely when not needed */
 .partner-col[hidden] { display: none; }
+
+/* Base cell look (optional guard if we want a common hook) */
+.max-euro {
+  position: relative;
+  font-weight: 600;
+}
+
+/* Colors: reuse the app’s “You / Partner” colors.
+   If you already have CSS variables, prefer those. */
+:root {
+  /* fallback colors if no existing tokens present */
+  --fm-self-bg: #0d5d47;     /* greenish used for "You" pill */
+  --fm-self-fg: #ffffff;
+  --fm-partner-bg: #2b4761;  /* bluish used for "Partner" pill */
+  --fm-partner-fg: #ffffff;
+
+  /* subtle border for contrast on dark themes */
+  --fm-hl-border: color-mix(in oklab, #000 15%, transparent);
+}
+
+/* Highlighted cell for the user */
+td.is-highlight-self {
+  background: var(--fm-self-bg);
+  color: var(--fm-self-fg);
+  border-radius: 8px;              /* keeps the same rounded feel as cards */
+  box-shadow: inset 0 0 0 1px var(--fm-hl-border);
+}
+
+/* Highlighted cell for the partner */
+td.is-highlight-partner {
+  background: var(--fm-partner-bg);
+  color: var(--fm-partner-fg);
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px var(--fm-hl-border);
+}
+
+/* Make the highlight fill the cell nicely without crowding */
+td.is-highlight-self,
+td.is-highlight-partner {
+  padding: 10px 12px;              /* a touch roomier */
+  transition: background-color .15s ease, color .15s ease;
+}
+
+/* Ensure long numbers stay readable */
+td.is-highlight-self .result,
+td.is-highlight-partner .result {
+  color: inherit;
+}
+
+/* If your table has zebra striping, the highlight should win */
+tr:nth-child(even) td.is-highlight-self {
+  background: var(--fm-self-bg);
+}
+tr:nth-child(even) td.is-highlight-partner {
+  background: var(--fm-partner-bg);
+}
+
+/* If a cell was previously styled via a row highlight, make sure it doesn't fight */
+tr.is-highlight-row td { background: transparent; }


### PR DESCRIPTION
## Summary
- highlight the appropriate max contribution cells instead of adding inline badges
- apply styles to shaded cells that reuse the existing You/Partner palette while keeping zebra striping intact

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68c9e0437ecc8333ad8cda08eae0b3c1