### PR TITLE
Adjust max table highlight styling

### DIFF
--- a/styles/results.css
+++ b/styles/results.css
@@ -150,11 +150,17 @@ td.is-highlight-partner .result {
 }
 
 /* If your table has zebra striping, the highlight should win */
-tr:nth-child(even) td.is-highlight-self {
-  background: var(--fm-self-bg);
-}
+tr:nth-child(even) td.is-highlight-self,
 tr:nth-child(even) td.is-highlight-partner {
-  background: var(--fm-partner-bg);
+  background: inherit; /* the class already sets bg; this line prevents double-blend */
+}
+
+tr:nth-child(even) td.is-highlight-self {
+  background-color: var(--fm-self-bg);
+}
+
+tr:nth-child(even) td.is-highlight-partner {
+  background-color: var(--fm-partner-bg);
 }
 
 /* If a cell was previously styled via a row highlight, make sure it doesn't fight */


### PR DESCRIPTION
## Summary
- ensure the highlighted max contribution cells keep their color even when zebra striping applies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e3fd1f1083339aa6c973678852df