### PR TITLE
Improve Full Monty restore flows

### DIFF
--- a/fullMontyWizard.js
+++ b/fullMontyWizard.js
@@ -1219,6 +1219,16 @@ function recalcAll(){
   updateContributionSummaryUI();
 }
 
+// Public: clear hero tweak session state so Results restore can reset UI cleanly
+window.resetContributionEdits = function resetContributionEdits(){
+  try {
+    actionStack.length = 0;
+    Object.keys(nudgeCounts).forEach(k => { nudgeCounts[k] = 0; });
+    _heroContribNudged = false;
+    if (typeof refreshContribUX === 'function') refreshContribUX();
+  } catch {}
+};
+
 function deepClone(obj){ return JSON.parse(JSON.stringify(obj)); }
 
 function announce(msg){
@@ -1632,11 +1642,10 @@ function restoreBaseline(){
   if (baselineSnapshot.retireAge !== undefined) patch.retireAge = baselineSnapshot.retireAge;
   setStore(patch);
 
-  actionStack.length = 0;
-  Object.keys(nudgeCounts).forEach(key => nudgeCounts[key]=0);
-  setUseMaxContributions(baselineSnapshot.useMaxContributions);
+  setUseMaxContributions(!!baselineSnapshot.useMaxContributions);
   recomputeAndRefreshUI();
   updateContributionSummaryUI();
+  window.resetContributionEdits?.();
   announce('Inputs restored to your original values.');
 }
 


### PR DESCRIPTION
## Summary
- replace the results restore handler with a hard reset that forces Maximise off, seeds wizard state from stored baselines and replays FY/Pension payloads
- guard retirement-age handling to avoid default values and ensure chips/UI only update when the age is known
- expose a wizard-side resetContributionEdits helper and use it during baseline restoration so contributions and hero tweaks clear correctly

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc11b119b48333a901e7cd8f837ed1