### PR TITLE
Remove placeholder tab from PDF generation

### DIFF
--- a/fullMontyPdf.js
+++ b/fullMontyPdf.js
@@ -1213,24 +1213,23 @@ async function _buildFullMontyPDF(run){
 
   // ---------- Save ----------
   const filename = 'Planeir_Full-Monty_Report.pdf';
+
+  // Try normal download first
+  let saveFailed = false;
   try {
-    // Primary path for desktop + most Android
     doc.save(filename);
   } catch (_) {
-    // fall through
+    saveFailed = true;
   }
 
-  // iOS/Safari often ignores programmatic downloads after async work.
-  // Open a blob URL in a (new) tab so the user gets a viewer/download.
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-                (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-
-  if (isIOS) {
-    const url = doc.output('bloburl');
-    const win = window.open(url, '_blank');
-    if (!win) {
-      // if popups are blocked, at least navigate current tab
-      window.location.href = url;
+  // Only if the save threw an error, provide a SAME-TAB fallback.
+  // (No new window; this navigates current tab to the PDF blob viewer.)
+  if (saveFailed) {
+    try {
+      const url = doc.output('bloburl');
+      window.location.href = url; // same-tab open of the PDF viewer
+    } catch (e) {
+      console.error('[PDF] Fallback blob navigation failed:', e);
     }
   }
 }

--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -1640,25 +1640,18 @@ async function handleGeneratePdfTap(e) {
   if (_pdfBuildInFlight) return;
   _pdfBuildInFlight = true;
 
-  // Optional: open a holder tab immediately on iOS to preserve activation
-  let holderWin = null;
-  try {
-    const isiOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-    if (isiOS) holderWin = window.open('about:blank', '_blank');
-  } catch {}
+  // 🚫 Removed: no more about:blank holder tab
 
   document.body.classList.add('pdf-exporting');
   try {
     const run = window.latestRun || (await buildPdfRunSnapshotSafely());
-    await buildFullMontyPDF(run); // iOS blob-url fallback lives in fullMontyPdf.js
+    await buildFullMontyPDF(run); // save logic lives in fullMontyPdf.js
   } catch (err) {
     console.error('[PDF] Failed to generate:', err);
     alert('Sorry — something interrupted PDF generation. Please try again.\n(Details in console)');
-    try { holderWin?.close(); } catch {}
   } finally {
     document.body.classList.remove('pdf-exporting');
-    _pdfBuildInFlight = false; // allow another tap after completion
+    _pdfBuildInFlight = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the about:blank holder tab from the Full Monty PDF trigger handler
- update the PDF save routine to fall back to same-tab blob navigation only when doc.save throws

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42c8c34bc8333a8c12443b4871801