### PR TITLE
Improve iOS PDF delivery with same-tab fallback

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -1632,33 +1632,22 @@ function onGeneratePdfDelegated(ev) {
 }
 
 async function handleGeneratePdfTap(e) {
-  // prevent accidental navigation/submit
   e?.preventDefault?.();
   e?.stopPropagation?.();
 
-  // De-dupe: if a previous tap is still building, ignore
   if (_pdfBuildInFlight) return;
   _pdfBuildInFlight = true;
-
-  // Optional: open a holder tab immediately on iOS to preserve activation
-  let holderWin = null;
-  try {
-    const isiOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-    if (isiOS) holderWin = window.open('about:blank', '_blank');
-  } catch {}
 
   document.body.classList.add('pdf-exporting');
   try {
     const run = window.latestRun || (await buildPdfRunSnapshotSafely());
-    await buildFullMontyPDF(run); // iOS blob-url fallback lives in fullMontyPdf.js
+    await buildFullMontyPDF(run); // save/open handled entirely in fullMontyPdf.js
   } catch (err) {
     console.error('[PDF] Failed to generate:', err);
     alert('Sorry — something interrupted PDF generation. Please try again.\n(Details in console)');
-    try { holderWin?.close(); } catch {}
   } finally {
     document.body.classList.remove('pdf-exporting');
-    _pdfBuildInFlight = false; // allow another tap after completion
+    _pdfBuildInFlight = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an iOS detection helper for deciding how to present the generated PDF
- navigate iOS users to a same-tab blob URL and keep non-iOS users on download with same-tab fallback
- keep the PDF trigger handler lean with a single in-flight guard and no placeholder tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42c8c34bc8333a8c12443b4871801