### PR TITLE
Embed PDF viewer wrapper with share toolbar

### DIFF
--- a/fullMontyPdf.js
+++ b/fullMontyPdf.js
@@ -30,13 +30,6 @@ const ACCENT_GREEN = '#00ff88';
 const ACCENT_CYAN  = '#0099ff';
 const COVER_GOLD   = '#BBA26F';
 
-function isIOSLike() {
-  const ua = navigator.userAgent || '';
-  const plt = navigator.platform || '';
-  const touchMac = plt === 'MacIntel' && navigator.maxTouchPoints > 1;
-  return /iPad|iPhone|iPod/.test(ua) || touchMac;
-}
-
 // ===== Summary panel constants =====
 const THEME = {
   bgPanel:  '#121417',
@@ -1218,35 +1211,9 @@ async function _buildFullMontyPDF(run){
   })();
   writeParagraph(doc, 'Note: Table shows personal age-related limits. Employer contributions are not subject to this €115,000 cap.', M + colW6 + colGap, yB, colW6, { size:10, color:'#CCCCCC' });
 
-  // ---------- Save & Return ----------
+  // ---------- Build blob & return (no navigation here) ----------
   const filename = 'Planeir_Full-Monty_Report.pdf';
   const pdfBlob = doc.output('blob');
-
-  let result = { blob: pdfBlob, filename, url: null, mode: 'unknown' };
-
-  if (isIOSLike()) {
-    // iOS/iPadOS: open viewer in SAME TAB so user can Share/Save
-    const url = URL.createObjectURL(pdfBlob);
-    result.url = url;
-    result.mode = 'ios-view';
-    window.location.assign(url);
-  } else {
-    // Desktop/Android: try normal download first
-    let savedOk = true;
-    try {
-      doc.save(filename);
-      result.mode = 'download';
-    } catch (e) {
-      savedOk = false;
-    }
-    if (!savedOk) {
-      const url = URL.createObjectURL(pdfBlob);
-      result.url = url;
-      result.mode = 'blob-view';
-      window.location.assign(url);
-    }
-  }
-
-  return result;
+  return { blob: pdfBlob, filename, url: null, mode: 'ready' };
 }
 

--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -7,134 +7,6 @@ import { buildFullMontyPDF } from './fullMontyPdf.js';
 // ===== PDF SNAPSHOT UTILITIES =====
 window.latestRun = window.latestRun || null;
 
-async function sharePdfFile(blob, filename) {
-  try {
-    const file = new File([blob], filename, { type: 'application/pdf' });
-
-    // Prefer canShare(files) (iOS/Android modern)
-    if (navigator.canShare && navigator.canShare({ files: [file] })) {
-      await navigator.share({
-        files: [file],
-        title: 'Planéir Report',
-        text: 'My Full-Monty report.'
-      });
-      return true;
-    }
-
-    // Fallback: if only URL sharing is supported and we have a viewer URL
-    if (navigator.share) {
-      // Caller may pass a url; we’ll accept it as a param in the wrapper below
-      return false; // let caller try url share if they want
-    }
-  } catch (err) {
-    // User cancelled or share failed — treat as unsupported so we show other options
-    console.warn('Share failed/cancelled:', err);
-  }
-  return false;
-}
-
-function showSharePanel({ blob, filename, url }) {
-  let panel = document.getElementById('pdf-share-panel');
-  if (!panel) {
-    panel = document.createElement('div');
-    panel.id = 'pdf-share-panel';
-    panel.style.position = 'fixed';
-    panel.style.left = '50%';
-    panel.style.bottom = '16px';
-    panel.style.transform = 'translateX(-50%)';
-    panel.style.zIndex = '9999';
-    panel.style.background = 'rgba(20,20,20,0.96)';
-    panel.style.color = '#fff';
-    panel.style.border = '1px solid rgba(255,255,255,0.12)';
-    panel.style.borderRadius = '10px';
-    panel.style.padding = '10px 12px';
-    panel.style.display = 'flex';
-    panel.style.gap = '8px';
-    panel.style.flexWrap = 'wrap';
-    panel.style.fontSize = '14px';
-
-    const mkBtn = (label) => {
-      const b = document.createElement('button');
-      b.type = 'button';
-      b.textContent = label;
-      b.style.background = '#2b2f36';
-      b.style.border = '1px solid #3a3f47';
-      b.style.color = '#ffffff';
-      b.style.borderRadius = '8px';
-      b.style.padding = '8px 10px';
-      b.style.cursor = 'pointer';
-      b.style.fontSize = '13px';
-      b.style.lineHeight = '1';
-      return b;
-    };
-
-    const shareBtn = mkBtn('Share…');
-    shareBtn.id = 'pdfShareBtn';
-    const dlBtn = mkBtn('Download again');
-    dlBtn.id = 'pdfDownloadBtn';
-    const closeBtn = mkBtn('Close');
-
-    panel.append('Your PDF is ready:', shareBtn, dlBtn, closeBtn);
-    document.body.appendChild(panel);
-
-    closeBtn.addEventListener('click', () => panel.remove());
-
-    dlBtn.addEventListener('click', () => {
-      try {
-        const a = document.createElement('a');
-        const urlAgain = URL.createObjectURL(blob);
-        a.href = urlAgain;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        setTimeout(() => URL.revokeObjectURL(urlAgain), 4000);
-      } catch (e) {
-        console.error('Download again failed:', e);
-      }
-    });
-
-    shareBtn.addEventListener('click', async () => {
-      const ok = await sharePdfFile(blob, filename);
-      if (!ok && navigator.share && url) {
-        try { await navigator.share({ title: 'Planéir Report', url }); } catch {}
-      } else if (!ok) {
-        alert('Sharing this file is not supported on this device/browser.');
-      }
-    });
-  } else {
-    // Rewire share button with the newest blob/url
-    const shareBtn = panel.querySelector('#pdfShareBtn');
-    if (shareBtn) {
-      shareBtn.onclick = async () => {
-        const ok = await sharePdfFile(blob, filename);
-        if (!ok && navigator.share && url) {
-          try { await navigator.share({ title: 'Planéir Report', url }); } catch {}
-        } else if (!ok) {
-          alert('Sharing this file is not supported on this device/browser.');
-        }
-      };
-    }
-    const dlBtn = panel.querySelector('#pdfDownloadBtn');
-    if (dlBtn) {
-      dlBtn.onclick = () => {
-        try {
-          const a = document.createElement('a');
-          const urlAgain = URL.createObjectURL(blob);
-          a.href = urlAgain;
-          a.download = filename;
-          document.body.appendChild(a);
-          a.click();
-          a.remove();
-          setTimeout(() => URL.revokeObjectURL(urlAgain), 4000);
-        } catch (e) {
-          console.error('Download again failed:', e);
-        }
-      };
-    }
-  }
-}
-
 /**
  * Try to read a number from a DOM node's text (e.g. "65" or "Age 65")
  */
@@ -1769,11 +1641,118 @@ async function handleGeneratePdfTap(e) {
   document.body.classList.add('pdf-exporting');
   try {
     const run = window.latestRun || (await buildPdfRunSnapshotSafely());
-    const pdfResult = await buildFullMontyPDF(run); // { blob, filename, url, mode }
-    if (pdfResult?.blob && pdfResult?.filename) {
-      // Offer Share (attachments via Web Share API on phones), + Download again
-      showSharePanel(pdfResult);
+    const pdfResult = await buildFullMontyPDF(run); // { blob, filename, mode:'ready' }
+    if (!pdfResult?.blob) throw new Error('No PDF blob');
+
+    const pdfUrl = URL.createObjectURL(pdfResult.blob);
+    const safeName = (pdfResult.filename || 'report.pdf').replace(/[^\w.\- ]+/g, '_');
+
+    // Build a tiny HTML page that shows the PDF full-screen and overlays a Share/Download toolbar.
+    // It re-fetches the blob URL to create a File for Web Share (so the button can attach the PDF).
+    const wrapperHtml = `
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>${safeName}</title>
+<style>
+  html,body {margin:0;height:100%;background:#000;}
+  .wrap {position:fixed;inset:0;display:flex;flex-direction:column;background:#000;}
+  .bar {
+    position:fixed;left:0;right:0;top:0;display:flex;gap:8px;align-items:center;
+    padding:10px env(safe-area-inset-right) 10px env(safe-area-inset-left);
+    background:rgba(18,20,23,0.92);color:#fff;border-bottom:1px solid rgba(255,255,255,0.08);z-index:2;
+    -webkit-backdrop-filter:saturate(120%) blur(6px);backdrop-filter:saturate(120%) blur(6px);
+  }
+  .title {font-weight:600;font-size:14px;margin-inline-end:auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:50vw}
+  .btn {
+    background:#2b2f36;border:1px solid #3a3f47;color:#fff;border-radius:10px;padding:9px 12px;
+    font-size:13px;line-height:1;cursor:pointer;touch-action:manipulation;
+  }
+  .view {position:absolute;inset:0;top:48px;} /* below bar */
+  iframe,embed,object {width:100%;height:100%;border:0;background:#000;}
+  @media (max-width: 420px){ .title {max-width:40vw;} }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="bar">
+    <div class="title">${safeName}</div>
+    <button class="btn" id="shareBtn">Share…</button>
+    <button class="btn" id="dlBtn">Download</button>
+    <button class="btn" id="closeBtn">Close</button>
+  </div>
+  <div class="view">
+    <iframe id="pdfFrame" src="${pdfUrl}" allow="autoplay"></iframe>
+  </div>
+</div>
+<script>
+(function(){
+  const pdfSrc = '${pdfUrl}';
+  const filename = ${JSON.stringify(safeName)};
+
+  async function shareFile() {
+    try {
+      const resp = await fetch(pdfSrc, {cache:'no-store'});
+      const blob = await resp.blob();
+      const file = new File([blob], filename, { type: 'application/pdf' });
+
+      if (navigator.canShare && navigator.canShare({ files:[file] })) {
+        await navigator.share({ files:[file], title: 'Planéir Report', text: 'My Full-Monty report.' });
+      } else if (navigator.share) {
+        // Fallback: share just the URL (no attachment)
+        await navigator.share({ title: 'Planéir Report', url: pdfSrc });
+      } else {
+        alert('Sharing is not supported on this device/browser.');
+      }
+    } catch (e) {
+      console.warn('Share failed/cancelled:', e);
     }
+  }
+
+  function downloadAgain() {
+    try {
+      const a = document.createElement('a');
+      a.href = pdfSrc;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch (e) {
+      console.error('Download failed', e);
+    }
+  }
+
+  function closeOverlay() {
+    history.back();
+  }
+
+  document.getElementById('shareBtn').addEventListener('click', shareFile);
+  document.getElementById('dlBtn').addEventListener('click', downloadAgain);
+  document.getElementById('closeBtn').addEventListener('click', closeOverlay);
+
+  // Clean up blob URL when leaving this page
+  const cleanup = () => { try { URL.revokeObjectURL(pdfSrc); } catch {} };
+  window.addEventListener('pagehide', cleanup, { once:true });
+  window.addEventListener('unload', cleanup, { once:true });
+
+  // Improve back button: if user presses back, we're good (we'll revoke on pagehide)
+})();
+</script>
+</body>
+</html>
+`;
+
+    // Create wrapper HTML blob and navigate the SAME tab to it
+    const wrapperBlob = new Blob([wrapperHtml], { type: 'text/html' });
+    const wrapperUrl = URL.createObjectURL(wrapperBlob);
+    try {
+      // Push a history state so "Close" can call history.back()
+      history.pushState({ pdfWrap:true }, '', location.href);
+    } catch {}
+    window.location.replace(wrapperUrl);
+    // No need to revoke wrapperUrl here; it lives for this page's lifetime
   } catch (err) {
     console.error('[PDF] Failed to generate:', err);
     alert('Sorry — something interrupted PDF generation. Please try again.\n(Details in console)');


### PR DESCRIPTION
## Summary
- Update the full Monty PDF builder to return a blob result without triggering navigation or downloads directly.
- Swap the PDF generation handler to open an inline HTML wrapper that embeds the PDF with share, download, and close controls.
- Remove the old share panel logic in favour of the full-screen document viewer overlay.

## Testing
- Not run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68e54214f9808333baafb20de35ba093