### PR TITLE
Fix Full Monty PDF save flow across platforms

### DIFF
--- a/fullMontyPdf.js
+++ b/fullMontyPdf.js
@@ -25,14 +25,6 @@ function ensureJsPDF() {
   return __jsPDFCtorPromise;
 }
 
-function isIOSLike() {
-  const ua = navigator.userAgent || '';
-  const plt = navigator.platform || '';
-  const isiOS = /iPad|iPhone|iPod/.test(ua);
-  const touchMac = plt === 'MacIntel' && navigator.maxTouchPoints > 1; // iPadOS on Mac UA
-  return isiOS || touchMac;
-}
-
 const BG_DARK      = '#1a1a1a';
 const ACCENT_GREEN = '#00ff88';
 const ACCENT_CYAN  = '#0099ff';
@@ -1221,59 +1213,31 @@ async function _buildFullMontyPDF(run){
 
   // ---------- Export with platform-aware delivery ----------
   const filename = 'Planeir_Full-Monty_Report.pdf';
-  let lastBlob = null;
+
+  function isIOSLike() {
+    const ua = navigator.userAgent || '';
+    const plt = navigator.platform || '';
+    const touchMac = plt === 'MacIntel' && navigator.maxTouchPoints > 1;
+    return /iPad|iPhone|iPod/.test(ua) || touchMac;
+  }
 
   if (isIOSLike()) {
-    // iOS/iPadOS: open the PDF in a NEW TAB so Safari shows a native Close/Done button
-    // and the user can share from the viewer. No holder tab; open exactly once.
+    // iOS/iPadOS: open inline in the SAME TAB (no extra/blank tab).
+    // Use an object URL and DO NOT revoke immediately, let Safari keep it.
     try {
-      lastBlob = doc.output('blob');                 // create the PDF blob
-      const url  = URL.createObjectURL(lastBlob);    // make a stable blob URL
-      const win  = window.open(url, '_blank');       // open in new tab (user can close)
-      if (!win) window.location.assign(url);         // popup blocked: same-tab as last resort
-      // Revoke after a minute to keep the viewer happy (don’t revoke immediately)
-      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+      const blob = doc.output('blob');
+      const url  = URL.createObjectURL(blob);
+      window.location.href = url;                     // open viewer in current tab
+      setTimeout(() => URL.revokeObjectURL(url), 120000); // revoke later (2 min)
     } catch (e) {
-      console.error('[PDF] iOS open failed, trying direct save:', e);
+      // If anything fails, fall back to save (won’t hurt on iOS if it’s ignored)
       try { doc.save(filename); } catch {}
     }
   } else {
-    // Desktop/Android: classic file download first
-    let saved = true;
-    try {
-      doc.save(filename);
-    } catch (e) {
-      saved = false;
-      console.warn('[PDF] doc.save threw; falling back to download link.', e);
-    }
-
-    if (!saved) {
-      // Non-navigating fallback: programmatic <a download> click
-      try {
-        lastBlob = doc.output('blob');
-        const url  = URL.createObjectURL(lastBlob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        (document.body || document.documentElement).appendChild(a);
-        a.click();
-        a.remove();
-        // Revoke shortly after click (download already started)
-        setTimeout(() => URL.revokeObjectURL(url), 0);
-      } catch (e2) {
-        console.error('[PDF] Fallback download failed:', e2);
-      }
-    }
+    // Desktop/Android: simple download, no navigation, no viewer.
+    doc.save(filename);
   }
 
-  if (!lastBlob) {
-    try {
-      lastBlob = doc.output('blob');
-    } catch (_) {
-      lastBlob = null;
-    }
-  }
-
-  return { blob: lastBlob, filename, url: null, mode: 'dispatched' };
+  return { blob: null, filename, url: null, mode: 'dispatched' };
 }
 


### PR DESCRIPTION
## Summary
- update the Full Monty PDF builder to route iOS downloads through a same-tab blob URL and keep desktop/android on doc.save
- simplify the PDF button handler to prevent default navigation, guard against double fires, and strip hrefs from link-based buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6c8adecb08333b0ddd057ba8ac5f4