### PR TITLE
Add Excel export for Full Monty results

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -4,6 +4,209 @@ import { sftForYear, CPI, STATE_PENSION, SP_START, MAX_SALARY_CAP } from './shar
 import { buildWarningsHTML } from './shared/warnings.js';
 import { buildFullMontyPDF } from './fullMontyPdf.js';
 
+let __xlsxReady;
+function ensureXLSX() {
+  if (__xlsxReady) return __xlsxReady;
+  __xlsxReady = new Promise((resolve, reject) => {
+    if (window.XLSX) return resolve(window.XLSX);
+
+    const s = document.createElement('script');
+    s.src = 'https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js';
+    s.async = true;
+    s.onload = () => (window.XLSX ? resolve(window.XLSX) : reject(new Error('XLSX failed to load')));
+    s.onerror = () => reject(new Error('Failed to load XLSX script'));
+    document.head.appendChild(s);
+  });
+  return __xlsxReady;
+}
+
+function getExportTrace() {
+  if (window.__FM_TRACE__?.current?.steps?.length) return window.__FM_TRACE__;
+
+  const now = new Date().toISOString();
+  const meta = {
+    now,
+    year0: window.latestRun?.year0 ?? new Date().getFullYear(),
+    dob: window.latestRun?.dob ?? null,
+    currentAge: window.latestRun?.age ?? null,
+    retireAge: window.latestRun?.retireAge ?? null,
+    salaryNow: window.latestRun?.salary ?? null,
+    salaryCapUsed: Math.min(
+      window.latestRun?.salary ?? 0,
+      typeof MAX_SALARY_CAP !== 'undefined' ? MAX_SALARY_CAP : window.latestRun?.salary ?? 0
+    ),
+    growthAssumption: window.latestRun?.growth ?? null,
+    feeAssumption: window.latestRun?.fee ?? null,
+    cpiAssumption: typeof CPI !== 'undefined' ? CPI : window.latestRun?.cpi ?? null,
+    statePension: {
+      START: typeof SP_START !== 'undefined' ? SP_START : window.latestRun?.spStart ?? null,
+      amount: typeof STATE_PENSION !== 'undefined' ? STATE_PENSION : window.latestRun?.spAmount ?? null
+    },
+    targetIncomePctOfSalary: window.latestRun?.targetIncomePctOfSalary ?? null,
+    personalPct: window.latestRun?.personalPct ?? null,
+    employerPct: window.latestRun?.employerPct ?? null
+  };
+
+  function buildStepsFrom(run, scenarioName = 'current') {
+    if (!run) return [];
+    const len = Math.max(run.labels?.length || 0, run.balances?.length || 0);
+    const rows = [];
+    for (let i = 0; i < len; i++) {
+      rows.push({
+        year: (meta.year0 ?? new Date().getFullYear()) + i,
+        age: meta.currentAge != null ? meta.currentAge + i : null,
+        scenario: scenarioName,
+        mode:
+          run.modes?.[i] ||
+          (meta.retireAge && meta.currentAge != null && meta.currentAge + i >= meta.retireAge
+            ? 'drawdown'
+            : 'accumulation'),
+        salary: run.salarySeries?.[i] ?? meta.salaryCapUsed ?? null,
+        personalContrib: run.personalContrib?.[i] ?? null,
+        employerContrib: run.employerContrib?.[i] ?? null,
+        grossContrib: run.grossContrib?.[i] ?? null,
+        preFeeGrowth: run.growthSeries?.[i] ?? null,
+        fee: run.feeSeries?.[i] ?? null,
+        statePension: run.statePension?.[i] ?? null,
+        targetNetIncome: run.targetNetIncome?.[i] ?? null,
+        withdrawal: run.withdrawals?.[i] ?? null,
+        endBalance: run.balances?.[i] ?? null,
+        requiredPot: run.requiredPot?.[i] ?? null,
+        gapVsFY:
+          run.balances?.[i] != null && run.requiredPot?.[i] != null
+            ? run.balances[i] - run.requiredPot[i]
+            : null,
+        sft: run.sftSeries?.[i] ?? null
+      });
+    }
+    return rows;
+  }
+
+  return {
+    current: {
+      meta,
+      steps: buildStepsFrom(window.latestRun?.current, 'current')
+    },
+    max: window.latestRun?.max
+      ? {
+          meta,
+          steps: buildStepsFrom(window.latestRun?.max, 'max')
+        }
+      : null
+  };
+}
+
+async function downloadFullMontyExcel() {
+  const XLSX = await ensureXLSX();
+  const trace = getExportTrace();
+
+  const assumptions = [];
+  const m = trace.current?.meta || {};
+  function pushKV(k, v) {
+    assumptions.push({ Key: k, Value: v ?? '' });
+  }
+
+  pushKV('Generated At', m.now);
+  pushKV('Current Age', m.currentAge);
+  pushKV('Retirement Age', m.retireAge);
+  pushKV('Base Year (year0)', m.year0);
+  pushKV('Salary (today)', m.salaryNow);
+  pushKV('Salary Cap Used', m.salaryCapUsed);
+  pushKV('Target Income % of Salary (today)', m.targetIncomePctOfSalary);
+  pushKV('Personal % (Current scenario)', m.personalPct);
+  pushKV('Employer % (Current scenario)', m.employerPct);
+  pushKV('Growth Assumption (per annum)', m.growthAssumption);
+  pushKV('Fee Assumption (per annum)', m.feeAssumption);
+  pushKV('CPI Assumption (per annum)', m.cpiAssumption);
+  pushKV('State Pension Start Age', m.statePension?.START);
+  pushKV('State Pension Annual (today €)', m.statePension?.amount);
+
+  const wsAss = XLSX.utils.json_to_sheet(assumptions);
+
+  const rows = [];
+  const cSteps = trace.current?.steps || [];
+  const mSteps = trace.max?.steps || [];
+  rows.push(...cSteps);
+  if (mSteps.length) rows.push(...mSteps);
+
+  const COLS = [
+    'scenario',
+    'year',
+    'age',
+    'mode',
+    'salary',
+    'personalContrib',
+    'employerContrib',
+    'grossContrib',
+    'preFeeGrowth',
+    'fee',
+    'statePension',
+    'targetNetIncome',
+    'withdrawal',
+    'endBalance',
+    'requiredPot',
+    'gapVsFY',
+    'sft'
+  ];
+
+  const wsRes = XLSX.utils.json_to_sheet(rows, { header: COLS });
+  wsRes['!cols'] = COLS.map(c => ({ wch: Math.max(12, String(c).length + 2) }));
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, wsAss, 'Assumptions & Inputs');
+  XLSX.utils.book_append_sheet(wb, wsRes, 'Results');
+
+  const dt = new Date();
+  const y = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getDate()).padStart(2, '0');
+  const hh = String(dt.getHours()).padStart(2, '0');
+  const min = String(dt.getMinutes()).padStart(2, '0');
+  const fname = `Planéir_FullMonty_Data_${y}-${mm}-${dd}_${hh}${min}.xlsx`;
+
+  XLSX.writeFile(wb, fname, { compression: true });
+}
+
+function mountDownloadDataButton() {
+  if (document.getElementById('btnDownloadData')) return;
+
+  const pdfBtn = document.querySelector('[data-action="download-pdf"], #btnDownloadPDF, .js-download-pdf');
+  const container = pdfBtn?.parentElement || document.querySelector('.results-actions') || document.querySelector('#resultsHeader');
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.id = 'btnDownloadData';
+  btn.className = 'btn ghost small';
+  btn.innerHTML = `
+    <span class="icon" aria-hidden="true" style="display:inline-flex;margin-right:6px;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+        <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
+        <path d="M8 4v16M16 4v16M3 9h18M3 14h18" stroke="currentColor" stroke-width="1.5"/>
+      </svg>
+    </span>
+    Download data
+  `;
+  btn.title = 'Download inputs and year-by-year results as Excel';
+  btn.style.cssText = `
+    all: unset; cursor: pointer;
+    display:inline-flex; align-items:center; gap:6px;
+    padding:8px 12px; border-radius:10px;
+    border:1px solid var(--surface-3, #2a2a2a);
+    background: var(--surface-2, #161616); color: var(--text-1, #e9e9e9);
+    box-shadow: 0 1px 0 rgba(0,0,0,.3);
+  `;
+  btn.onmouseenter = () => (btn.style.borderColor = 'var(--accent, #c000ff)');
+  btn.onmouseleave = () => (btn.style.borderColor = 'var(--surface-3, #2a2a2a)');
+
+  (container || document.body).appendChild(btn);
+  btn.addEventListener('click', () => {
+    downloadFullMontyExcel().catch(err => {
+      console.error('[Excel] Download failed', err);
+      alert('Sorry — Excel export failed. Please try again.');
+    });
+  });
+}
+
 // ===== PDF SNAPSHOT UTILITIES =====
 window.latestRun = window.latestRun || null;
 
@@ -1694,9 +1897,14 @@ function rebindGeneratePdfButton() {
     btn.parentNode.replaceChild(fresh, btn);
     fresh.addEventListener(ACTIVATE_EVT, handleGeneratePdfTap, { passive: false });
   });
+
+  mountDownloadDataButton();
 }
 
 document.addEventListener('DOMContentLoaded', rebindGeneratePdfButton);
 window.addEventListener('fm-renderer-ready', rebindGeneratePdfButton);
+document.addEventListener('DOMContentLoaded', mountDownloadDataButton);
+window.addEventListener('fm-renderer-ready', mountDownloadDataButton);
+window.addEventListener('fm:results:ready', mountDownloadDataButton);
 
 // Keep restore hidden on any re-render of results


### PR DESCRIPTION
## Summary
- add a lazy-loaded SheetJS helper and Excel export builder that outputs assumptions and year-by-year trace
- provide a fallback trace assembler so exports work even without the rich debug trace
- mount a "Download data" action beside the PDF control and re-run the placement on results rerenders

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68eb83b94c0483338eb6ee7dd11b18ad