### PR TITLE
Remove fees from Excel export and relocate download icon

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -5,70 +5,40 @@ import { buildWarningsHTML } from './shared/warnings.js';
 import { buildFullMontyPDF } from './fullMontyPdf.js';
 import { downloadFullMontyExcel } from './shared/exportExcel.js';
 
-function mountDownloadDataButton() {
-  if (document.getElementById('btnDownloadData')) return;
+function mountPillExportIcons() {
+  const candidates = [
+    document.querySelector('#beforeRetirement .pills, #beforeRetirement .pill-row, #beforeRetirement [data-pills]'),
+    document.querySelector('#duringRetirement .pills, #duringRetirement .pill-row, #duringRetirement [data-pills]'),
+  ].filter(Boolean);
 
-  const pdfBtn = document.querySelector('[data-action="download-pdf"], #btnDownloadPDF, .js-download-pdf');
-  const container = pdfBtn?.parentElement || document.querySelector('.results-actions') || document.querySelector('#resultsHeader');
+  if (!candidates.length) {
+    document.querySelectorAll('.results-hero .pills, .results-hero .pill-row, .results-header .pills, .results-header .pill-row')
+      .forEach(el => candidates.push(el));
+  }
 
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.id = 'btnDownloadData';
-  btn.className = 'btn ghost small';
-  btn.innerHTML = `
-    <span class="icon" aria-hidden="true" style="display:inline-flex;margin-right:6px;">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-        <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M8 4v16M16 4v16M3 9h18M3 14h18" stroke="currentColor" stroke-width="1.5"/>
-      </svg>
-    </span>
-    Download data
-  `;
-  btn.title = 'Download inputs and year-by-year results as Excel';
-  btn.style.cssText = `
-    all: unset; cursor: pointer;
-    display:inline-flex; align-items:center; gap:6px;
-    padding:8px 12px; border-radius:10px;
-    border:1px solid var(--surface-3, #2a2a2a);
-    background: var(--surface-2, #161616); color: var(--text-1, #e9e9e9);
-    box-shadow: 0 1px 0 rgba(0,0,0,.3);
-  `;
-  btn.onmouseenter = () => (btn.style.borderColor = 'var(--accent, #c000ff)');
-  btn.onmouseleave = () => (btn.style.borderColor = 'var(--surface-3, #2a2a2a)');
+  candidates.forEach(container => {
+    if (!container || container.dataset.exportMounted === '1') return;
+    container.dataset.exportMounted = '1';
 
-  (container || document.body).appendChild(btn);
-  btn.addEventListener('click', () => {
-    downloadFullMontyExcel().catch(err => {
-      console.error('[Excel] Download failed', err);
-      alert('Sorry — Excel export failed. Please try again.');
-    });
-  });
-}
-
-// Mount tiny export icon inside each chart card without changing layout
-function mountInlineExportIcons() {
-  // Be liberal in selecting chart wrappers:
-  const cards = document.querySelectorAll('.chart-card, .results-card, .graph-card');
-  cards.forEach(card => {
-    if (card.querySelector('.chart-export-btn')) return;
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'chart-export-btn';
-    btn.title = 'Download data';
-    btn.setAttribute('aria-label','Download data');
+    btn.className = 'pill-export-btn';
+    btn.title = 'Download data (Excel)';
+    btn.setAttribute('aria-label', 'Download data (Excel)');
     btn.innerHTML = `
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
         <path d="M8 4v16M16 4v16M3 9h18M3 14h18" stroke="currentColor" stroke-width="1.5"/>
       </svg>
     `;
+
+    container.appendChild(btn);
     btn.addEventListener('click', () => {
       downloadFullMontyExcel().catch(err => {
         console.error('[Excel] Download failed', err);
         alert('Sorry — Excel export failed. Please try again.');
       });
     });
-    card.appendChild(btn);
   });
 }
 
@@ -1763,15 +1733,16 @@ function rebindGeneratePdfButton() {
     fresh.addEventListener(ACTIVATE_EVT, handleGeneratePdfTap, { passive: false });
   });
 
-  mountDownloadDataButton();
 }
 
 document.addEventListener('DOMContentLoaded', rebindGeneratePdfButton);
 window.addEventListener('fm-renderer-ready', rebindGeneratePdfButton);
-document.addEventListener('DOMContentLoaded', mountDownloadDataButton);
-window.addEventListener('fm-renderer-ready', mountDownloadDataButton);
-window.addEventListener('fm:results:ready', mountDownloadDataButton);
-document.addEventListener('fm:results:ready', mountInlineExportIcons);
-document.addEventListener('DOMContentLoaded', mountInlineExportIcons);
+document.addEventListener('fm:results:ready', mountPillExportIcons);
+document.addEventListener('DOMContentLoaded', mountPillExportIcons);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const legacy = document.getElementById('btnDownloadData');
+  if (legacy) legacy.remove();
+});
 
 // Keep restore hidden on any re-render of results

--- a/styles/results.css
+++ b/styles/results.css
@@ -196,20 +196,24 @@ tr.is-highlight-row td { background: transparent; }
 
 .chart-card { position: relative; }
 
-.chart-export-btn {
-  position: absolute; top: 8px; right: 8px;
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 32px; height: 32px; border-radius: 10px;
+/* Inline pill export icon (sits beside pills row, not overlapping info icon) */
+.pill-export-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  margin-left: 8px;
+  border-radius: 8px;
   border: 1px solid var(--surface-3, #2a2a2a);
-  background: var(--surface-2, #151518); color: var(--text-1, #e9e9e9);
-  cursor: pointer; opacity: .88; transition: transform .15s ease, opacity .15s ease, border-color .15s ease;
+  background: var(--surface-2, #151518);
+  color: var(--text-1, #e9e9e9);
+  cursor: pointer;
+  vertical-align: middle;
+  transition: transform .15s ease, opacity .15s ease, border-color .15s ease;
 }
-.chart-export-btn:hover { opacity: 1; border-color: var(--accent, #c000ff); transform: translateY(-1px); }
-.chart-export-btn svg { pointer-events: none; }
-.chart-export-btn[aria-label]::after {
-  content: attr(aria-label);
-  position: absolute; right: 36px; top: 50%; transform: translateY(-50%);
-  background: #111; color: #ddd; font-size: 11px; padding: 4px 6px; border-radius: 6px;
-  border: 1px solid #333; white-space: nowrap; opacity: 0; pointer-events: none; transition: opacity .12s ease;
-}
-.chart-export-btn:hover::after { opacity: 1; }
+.pill-export-btn:hover { border-color: var(--accent, #00e676); transform: translateY(-1px); }
+.pill-export-btn svg { pointer-events: none; }
+.pill-export-btn + .pill, .pill + .pill-export-btn { margin-left: 8px; }
+
+/* tiny tooltip via title attr is enough; avoid custom popover to keep it light */


### PR DESCRIPTION
## Summary
- remove fee handling from the Excel assumptions/results export and rely on growth-only returns
- simplify the investment return and withdrawal formulas while keeping the closing balance aligned with contributions
- restyle and remount the download icon beside the pills, removing the old chart and sidebar buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eb90f14cd483338c9fc62dc17f7e46