### PR TITLE
Improve pill export mounting

### DIFF
--- a/fullMontyResults.js
+++ b/fullMontyResults.js
@@ -6,40 +6,57 @@ import { buildFullMontyPDF } from './fullMontyPdf.js';
 import { downloadFullMontyExcel } from './shared/exportExcel.js';
 
 function mountPillExportIcons() {
-  const candidates = [
-    document.querySelector('#beforeRetirement .pills, #beforeRetirement .pill-row, #beforeRetirement [data-pills]'),
-    document.querySelector('#duringRetirement .pills, #duringRetirement .pill-row, #duringRetirement [data-pills]'),
-  ].filter(Boolean);
+  if (mountPillExportIcons._scheduled) return;
+  mountPillExportIcons._scheduled = true;
 
-  if (!candidates.length) {
-    document.querySelectorAll('.results-hero .pills, .results-hero .pill-row, .results-header .pills, .results-header .pill-row')
-      .forEach(el => candidates.push(el));
-  }
+  const afterPaint = () => {
+    mountPillExportIcons._scheduled = false;
 
-  candidates.forEach(container => {
-    if (!container || container.dataset.exportMounted === '1') return;
-    container.dataset.exportMounted = '1';
+    const listA = Array.from(document.querySelectorAll(
+      '#beforeRetirement .pills, #beforeRetirement .pill-row, #beforeRetirement [data-pills],' +
+      '#duringRetirement .pills, #duringRetirement .pill-row, #duringRetirement [data-pills]'
+    ));
 
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'pill-export-btn';
-    btn.title = 'Download data (Excel)';
-    btn.setAttribute('aria-label', 'Download data (Excel)');
-    btn.innerHTML = `
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M8 4v16M16 4v16M3 9h18M3 14h18" stroke="currentColor" stroke-width="1.5"/>
-      </svg>
-    `;
+    const listB = Array.from(document.querySelectorAll(
+      '#phase-pre .pills, #phase-pre .pill-row, #phase-pre [data-pills],' +
+      '#phase-post .pills, #phase-post .pill-row, #phase-post [data-pills]'
+    ));
 
-    container.appendChild(btn);
-    btn.addEventListener('click', () => {
-      downloadFullMontyExcel().catch(err => {
-        console.error('[Excel] Download failed', err);
-        alert('Sorry — Excel export failed. Please try again.');
+    const listC = Array.from(document.querySelectorAll(
+      '#resultsView .pills, #resultsView .pill-row, #resultsView [data-pills]'
+    ));
+
+    const candidates = [...listA, ...listB, ...listC];
+
+    document.querySelectorAll('.chart-export-btn').forEach(el => el.remove());
+
+    candidates.forEach(container => {
+      if (!container || container.dataset.exportMounted === '1') return;
+
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'pill-export-btn';
+      btn.title = 'Download data (Excel)';
+      btn.setAttribute('aria-label', 'Download data (Excel)');
+      btn.innerHTML = `
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M8 4v16M16 4v16M3 9h18M3 14h18" stroke="currentColor" stroke-width="1.5"/>
+        </svg>
+      `;
+      btn.addEventListener('click', () => {
+        downloadFullMontyExcel().catch(err => {
+          console.error('[Excel] Download failed', err);
+          alert('Sorry — Excel export failed. Please try again.');
+        });
       });
+
+      container.appendChild(btn);
+      container.dataset.exportMounted = '1';
     });
-  });
+  };
+
+  requestAnimationFrame(() => requestAnimationFrame(afterPaint));
 }
 
 // ===== PDF SNAPSHOT UTILITIES =====


### PR DESCRIPTION
## Summary
- defer mounting the pill export buttons until after the results DOM has painted
- collect all potential pill rows across pre/post phases and fallback results wrappers
- prevent duplicate mounts and remove any legacy chart export buttons before adding the new control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb95a40f288333b11225f49dd3976f